### PR TITLE
Add theme selection

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -30,6 +30,7 @@ export default function App() {
   const [savingScore, setSavingScore] = useState(false);
   const [lbError, setLbError] = useState<string | null>(null);
   const [showProfile, setShowProfile] = useState(false);
+  const [theme, setTheme] = useState<'light' | 'dark'>('dark');
   const gameEngineRef = useRef<any>(null);
 
   useEffect(() => {
@@ -150,15 +151,27 @@ export default function App() {
   );
 
   if (!user) {
-    return <AuthScreen onAuth={setUser} uiLanguage={uiLanguage} onLanguageChange={setUiLanguage} />;
+    return (
+      <AuthScreen
+        onAuth={setUser}
+        uiLanguage={uiLanguage}
+        onLanguageChange={setUiLanguage}
+        theme={theme}
+      />
+    );
   }
 
   if (!selectedLanguage) {
     return (
-      <View style={{ flex: 1, backgroundColor: '#1e1e1e' }}>
+      <View style={{ flex: 1, backgroundColor: theme === 'light' ? '#fff' : '#1e1e1e' }}>
         {ProfileButton}
         {/* Sadece dil seçtir, level yok */}
-        <LanguageSelector onSelect={handleLanguageSelect} uiLanguage={uiLanguage} />
+        <LanguageSelector
+          onSelect={handleLanguageSelect}
+          uiLanguage={uiLanguage}
+          theme={theme}
+          onThemeChange={setTheme}
+        />
         {showProfile && (
           <View style={[styles.leaderboardModal, { zIndex: 40 }]}> {/* Modal gibi üstte */}
             <ProfileScreen visible={showProfile} onClose={() => setShowProfile(false)} uiLanguage={uiLanguage} />
@@ -173,7 +186,7 @@ export default function App() {
 
   if (loadingSnippets) {
     return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: '#1e1e1e' }}>
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: theme === 'light' ? '#fff' : '#1e1e1e' }}>
         {ProfileButton}
         <ActivityIndicator size="large" color="#61dafb" />
         <Text style={{ color: 'white', marginTop: 20 }}>{t(uiLanguage, 'loadingQuestions')}</Text>
@@ -191,7 +204,7 @@ export default function App() {
 
   if (fetchError) {
     return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: '#1e1e1e' }}>
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: theme === 'light' ? '#fff' : '#1e1e1e' }}>
         {ProfileButton}
         <Text style={{ color: 'red', marginBottom: 20 }}>{fetchError}</Text>
         <Button title={t(uiLanguage, 'tryAgain')} onPress={() => handleLanguageSelect(selectedLanguage!)} />
@@ -239,7 +252,7 @@ export default function App() {
   const entities = {};
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { backgroundColor: theme === 'light' ? '#fff' : '#1e1e1e' }]}>
       {LevelBox}
       {InfoBar}
       <GameEngine

--- a/components/AuthScreen.tsx
+++ b/components/AuthScreen.tsx
@@ -10,10 +10,12 @@ export default function AuthScreen({
   onAuth,
   uiLanguage,
   onLanguageChange,
+  theme,
 }: {
   onAuth: (user: any) => void;
   uiLanguage: Lang;
   onLanguageChange: (lang: Lang) => void;
+  theme: 'light' | 'dark';
 }) {
   const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
@@ -51,7 +53,7 @@ export default function AuthScreen({
   };
 
   return (
-    <View style={styles.authContainer}>
+    <View style={[styles.authContainer, { backgroundColor: theme === 'light' ? '#fff' : '#1e1e1e' }]}>
       <View style={styles.langRow}>
         <TouchableOpacity
           style={[styles.langButton, uiLanguage === 'tr' && styles.langButtonActive]}

--- a/components/LanguageSelector.tsx
+++ b/components/LanguageSelector.tsx
@@ -2,7 +2,17 @@ import React, { useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
 import { Lang, t } from '../translations';
 
-export const LanguageSelector = ({ onSelect, uiLanguage }: { onSelect: (lang: string) => void; uiLanguage: Lang }) => {
+export const LanguageSelector = ({
+  onSelect,
+  uiLanguage,
+  theme,
+  onThemeChange,
+}: {
+  onSelect: (lang: string) => void;
+  uiLanguage: Lang;
+  theme: 'light' | 'dark';
+  onThemeChange: (t: 'light' | 'dark') => void;
+}) => {
   const [language, setLanguage] = useState<string | null>(null);
   const [showReady, setShowReady] = useState(false);
 
@@ -19,7 +29,7 @@ export const LanguageSelector = ({ onSelect, uiLanguage }: { onSelect: (lang: st
 
   if (showReady && language) {
     return (
-      <View style={styles.container}>
+      <View style={[styles.container, { backgroundColor: theme === 'light' ? '#fff' : '#1e1e1e' }]}>
         <Text style={styles.title}>{t(uiLanguage, 'ready')}</Text>
         <TouchableOpacity style={styles.readyButton} onPress={handleStart}>
           <Text style={styles.buttonText}>{t(uiLanguage, 'yes')}</Text>
@@ -29,7 +39,7 @@ export const LanguageSelector = ({ onSelect, uiLanguage }: { onSelect: (lang: st
   }
 
   return (
-    <View style={styles.container}>
+    <View style={[styles.container, { backgroundColor: theme === 'light' ? '#fff' : '#1e1e1e' }]}>
       <Text style={styles.title}>{t(uiLanguage, 'selectLanguage')}</Text>
       <View style={styles.buttonGrid}>
         <View style={styles.buttonRow}>
@@ -48,6 +58,15 @@ export const LanguageSelector = ({ onSelect, uiLanguage }: { onSelect: (lang: st
             <Text style={styles.buttonText}>Python</Text>
           </TouchableOpacity>
         </View>
+      </View>
+      <View style={[styles.buttonRow, { marginTop: 20 }]}> 
+        <Text style={[styles.title, { marginBottom: 10 }]}>{t(uiLanguage, 'selectTheme')}</Text>
+        <TouchableOpacity style={styles.button} onPress={() => onThemeChange('light')}>
+          <Text style={styles.buttonText}>{t(uiLanguage, 'light')}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.button} onPress={() => onThemeChange('dark')}>
+          <Text style={styles.buttonText}>{t(uiLanguage, 'dark')}</Text>
+        </TouchableOpacity>
       </View>
     </View>
   );

--- a/translations.ts
+++ b/translations.ts
@@ -43,6 +43,9 @@ export const translations: Record<Lang, Record<string, string>> = {
     languagesLevels: 'Diller & Seviyeler',
     noProgress: 'Henüz ilerleme yok.',
     countryLevel: 'Seviye',
+    selectTheme: 'Tema Seç',
+    light: 'Açık',
+    dark: 'Koyu',
   },
   en: {
     loginTitle: 'Login',
@@ -86,6 +89,9 @@ export const translations: Record<Lang, Record<string, string>> = {
     languagesLevels: 'Languages & Levels',
     noProgress: 'No progress yet.',
     countryLevel: 'Level',
+    selectTheme: 'Select Theme',
+    light: 'Light',
+    dark: 'Dark',
   },
 };
 


### PR DESCRIPTION
## Summary
- add translations for light/dark theme
- add theme property to AuthScreen and LanguageSelector
- allow picking light or dark theme before starting game
- show screens with appropriate background color

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687d15131b6c832692c7cb97bfd68229