### PR TITLE
Remove theme selection feature

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -30,7 +30,6 @@ export default function App() {
   const [savingScore, setSavingScore] = useState(false);
   const [lbError, setLbError] = useState<string | null>(null);
   const [showProfile, setShowProfile] = useState(false);
-  const [theme, setTheme] = useState<'light' | 'dark'>('dark');
   const gameEngineRef = useRef<any>(null);
 
   useEffect(() => {
@@ -151,27 +150,23 @@ export default function App() {
   );
 
   if (!user) {
-    return (
-      <AuthScreen
-        onAuth={setUser}
-        uiLanguage={uiLanguage}
-        onLanguageChange={setUiLanguage}
-        theme={theme}
-        onThemeChange={setTheme}
-      />
-    );
+      return (
+        <AuthScreen
+          onAuth={setUser}
+          uiLanguage={uiLanguage}
+          onLanguageChange={setUiLanguage}
+        />
+      );
   }
 
   if (!selectedLanguage) {
     return (
-      <View style={{ flex: 1, backgroundColor: theme === 'light' ? '#fff' : '#1e1e1e' }}>
+      <View style={{ flex: 1, backgroundColor: '#1e1e1e' }}>
         {ProfileButton}
         {/* Sadece dil seçtir, level yok */}
         <LanguageSelector
           onSelect={handleLanguageSelect}
           uiLanguage={uiLanguage}
-          theme={theme}
-          onThemeChange={setTheme}
         />
         {showProfile && (
           <View style={[styles.leaderboardModal, { zIndex: 40 }]}> {/* Modal gibi üstte */}
@@ -187,7 +182,7 @@ export default function App() {
 
   if (loadingSnippets) {
     return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: theme === 'light' ? '#fff' : '#1e1e1e' }}>
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: '#1e1e1e' }}>
         {ProfileButton}
         <ActivityIndicator size="large" color="#61dafb" />
         <Text style={{ color: 'white', marginTop: 20 }}>{t(uiLanguage, 'loadingQuestions')}</Text>
@@ -205,7 +200,7 @@ export default function App() {
 
   if (fetchError) {
     return (
-      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: theme === 'light' ? '#fff' : '#1e1e1e' }}>
+      <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center', backgroundColor: '#1e1e1e' }}>
         {ProfileButton}
         <Text style={{ color: 'red', marginBottom: 20 }}>{fetchError}</Text>
         <Button title={t(uiLanguage, 'tryAgain')} onPress={() => handleLanguageSelect(selectedLanguage!)} />
@@ -253,7 +248,7 @@ export default function App() {
   const entities = {};
 
   return (
-    <View style={[styles.container, { backgroundColor: theme === 'light' ? '#fff' : '#1e1e1e' }]}>
+    <View style={[styles.container, { backgroundColor: '#1e1e1e' }]}>
       {LevelBox}
       {InfoBar}
       <GameEngine

--- a/components/AuthScreen.tsx
+++ b/components/AuthScreen.tsx
@@ -10,14 +10,11 @@ export default function AuthScreen({
   onAuth,
   uiLanguage,
   onLanguageChange,
-  theme,
-  onThemeChange,
 }: {
   onAuth: (user: any) => void;
   uiLanguage: Lang;
   onLanguageChange: (lang: Lang) => void;
-  theme: 'light' | 'dark';
-  onThemeChange: (t: 'light' | 'dark') => void;
+
 }) {
   const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
@@ -28,9 +25,6 @@ export default function AuthScreen({
   const [registerSuccess, setRegisterSuccess] = useState(false);
   const [country, setCountry] = useState('TR');
 
-  const handleThemeToggle = () => {
-    onThemeChange(theme === 'light' ? 'dark' : 'light');
-  };
 
   const handleSubmit = async () => {
     setLoading(true);
@@ -59,7 +53,7 @@ export default function AuthScreen({
   };
 
   return (
-    <View style={[styles.authContainer, { backgroundColor: theme === 'light' ? '#fff' : '#1e1e1e' }]}>
+    <View style={[styles.authContainer, { backgroundColor: '#1e1e1e' }]}>
       <View style={styles.langRow}>
         <TouchableOpacity
           style={[styles.langButton, uiLanguage === 'tr' && styles.langButtonActive]}
@@ -72,14 +66,6 @@ export default function AuthScreen({
           onPress={() => onLanguageChange('en')}
         >
           <Text style={styles.langButtonText}>EN</Text>
-        </TouchableOpacity>
-        <TouchableOpacity
-          style={styles.langButton}
-          onPress={handleThemeToggle}
-        >
-          <Text style={styles.langButtonText}>
-            {theme === 'light' ? t(uiLanguage, 'dark') : t(uiLanguage, 'light')}
-          </Text>
         </TouchableOpacity>
       </View>
       <View style={styles.authBox}>

--- a/components/LanguageSelector.tsx
+++ b/components/LanguageSelector.tsx
@@ -5,13 +5,10 @@ import { Lang, t } from '../translations';
 export const LanguageSelector = ({
   onSelect,
   uiLanguage,
-  theme,
-  onThemeChange,
 }: {
   onSelect: (lang: string) => void;
   uiLanguage: Lang;
-  theme: 'light' | 'dark';
-  onThemeChange: (t: 'light' | 'dark') => void;
+
 }) => {
   const [language, setLanguage] = useState<string | null>(null);
   const [showReady, setShowReady] = useState(false);
@@ -29,7 +26,7 @@ export const LanguageSelector = ({
 
   if (showReady && language) {
     return (
-      <View style={[styles.container, { backgroundColor: theme === 'light' ? '#fff' : '#1e1e1e' }]}>
+      <View style={[styles.container, { backgroundColor: '#1e1e1e' }]}>
         <Text style={styles.title}>{t(uiLanguage, 'ready')}</Text>
         <TouchableOpacity style={styles.readyButton} onPress={handleStart}>
           <Text style={styles.buttonText}>{t(uiLanguage, 'yes')}</Text>
@@ -39,7 +36,7 @@ export const LanguageSelector = ({
   }
 
   return (
-    <View style={[styles.container, { backgroundColor: theme === 'light' ? '#fff' : '#1e1e1e' }]}>
+    <View style={[styles.container, { backgroundColor: '#1e1e1e' }]}>
       <Text style={styles.title}>{t(uiLanguage, 'selectLanguage')}</Text>
       <View style={styles.buttonGrid}>
         <View style={styles.buttonRow}>
@@ -59,15 +56,7 @@ export const LanguageSelector = ({
           </TouchableOpacity>
         </View>
       </View>
-      <View style={[styles.buttonRow, { marginTop: 20 }]}> 
-        <Text style={[styles.title, { marginBottom: 10 }]}>{t(uiLanguage, 'selectTheme')}</Text>
-        <TouchableOpacity style={styles.button} onPress={() => onThemeChange('light')}>
-          <Text style={styles.buttonText}>{t(uiLanguage, 'light')}</Text>
-        </TouchableOpacity>
-        <TouchableOpacity style={styles.button} onPress={() => onThemeChange('dark')}>
-          <Text style={styles.buttonText}>{t(uiLanguage, 'dark')}</Text>
-        </TouchableOpacity>
-      </View>
+      {/* Theme selection removed */}
     </View>
   );
 };

--- a/translations.ts
+++ b/translations.ts
@@ -43,9 +43,6 @@ export const translations: Record<Lang, Record<string, string>> = {
     languagesLevels: 'Diller & Seviyeler',
     noProgress: 'Henüz ilerleme yok.',
     countryLevel: 'Seviye',
-    selectTheme: 'Tema Seç',
-    light: 'Açık',
-    dark: 'Koyu',
   },
   en: {
     loginTitle: 'Login',
@@ -89,9 +86,6 @@ export const translations: Record<Lang, Record<string, string>> = {
     languagesLevels: 'Languages & Levels',
     noProgress: 'No progress yet.',
     countryLevel: 'Level',
-    selectTheme: 'Select Theme',
-    light: 'Light',
-    dark: 'Dark',
   },
 };
 


### PR DESCRIPTION
## Summary
- remove light/dark theme selection across the app
- clean up translation keys for theme selection

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config file)*

------
https://chatgpt.com/codex/tasks/task_e_687d1ce13c208326a096467635730d9c