### PR TITLE
Add friend profile viewing

### DIFF
--- a/components/FriendsScreen.tsx
+++ b/components/FriendsScreen.tsx
@@ -4,6 +4,7 @@ import { theme } from '../theme';
 import { Lang, t } from '../translations';
 import { auth } from '../systems/auth';
 import { searchUsers, sendFriendRequest, fetchFriendRequests, fetchSentFriendRequests, acceptFriendRequest, fetchFriendsWithProgress } from '../systems/friends';
+import UserProfileScreen from './UserProfileScreen';
 
 export default function FriendsScreen({ visible, onClose, uiLanguage }: { visible: boolean; onClose: () => void; uiLanguage: Lang }) {
   const user = auth.currentUser;
@@ -15,6 +16,7 @@ export default function FriendsScreen({ visible, onClose, uiLanguage }: { visibl
   const [info, setInfo] = useState<string | null>(null);
   const [sentRequests, setSentRequests] = useState<string[]>([]);
   const [outgoingRequests, setOutgoingRequests] = useState<any[]>([]);
+  const [selectedFriend, setSelectedFriend] = useState<string | null>(null);
 
   useEffect(() => {
     if (visible && user?.displayName) {
@@ -56,6 +58,7 @@ export default function FriendsScreen({ visible, onClose, uiLanguage }: { visibl
   };
 
   return (
+    <>
     <Modal visible={visible} animationType="fade" transparent onRequestClose={onClose}>
       <View style={styles.overlay}>
         <View style={styles.card}>
@@ -118,6 +121,9 @@ export default function FriendsScreen({ visible, onClose, uiLanguage }: { visibl
               <View key={f.username} style={styles.row}>
                 <Text style={styles.name}>{f.username}</Text>
                 <Text style={styles.levelText}>{Object.entries(f.progress).map(([lang, lvl]) => `${lang.toUpperCase()}: ${lvl}`).join(', ')}</Text>
+                <TouchableOpacity style={styles.profileButton} onPress={() => setSelectedFriend(f.username)} activeOpacity={0.7}>
+                  <Text style={styles.buttonText}>{t(uiLanguage, 'viewProfile')}</Text>
+                </TouchableOpacity>
               </View>
             ))}
           </ScrollView>
@@ -127,6 +133,15 @@ export default function FriendsScreen({ visible, onClose, uiLanguage }: { visibl
         </View>
       </View>
     </Modal>
+    {selectedFriend && (
+      <UserProfileScreen
+        visible={true}
+        onClose={() => setSelectedFriend(null)}
+        username={selectedFriend}
+        uiLanguage={uiLanguage}
+      />
+    )}
+    </>
   );
 }
 
@@ -176,6 +191,13 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     paddingHorizontal: 10,
     paddingVertical: 4,
+  },
+  profileButton: {
+    backgroundColor: theme.colors.primary,
+    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 4,
+    marginLeft: 6,
   },
   buttonText: {
     color: theme.colors.text,

--- a/components/UserProfileScreen.tsx
+++ b/components/UserProfileScreen.tsx
@@ -1,0 +1,180 @@
+import React, { useEffect, useState } from 'react';
+import { Modal, View, Text, StyleSheet, ActivityIndicator, ScrollView, TouchableOpacity } from 'react-native';
+import { theme } from '../theme';
+import { Lang, t } from '../translations';
+import { fetchUserProgress } from '../systems/leaderboard';
+import { doc, getDoc } from 'firebase/firestore';
+import { db } from '../firebaseConfig';
+import { countries } from './countries';
+
+export default function UserProfileScreen({ visible, onClose, username, uiLanguage }: { visible: boolean; onClose: () => void; username: string; uiLanguage: Lang }) {
+  const [progress, setProgress] = useState<any>({});
+  const [loading, setLoading] = useState(true);
+  const [email, setEmail] = useState<string | null>(null);
+  const [country, setCountry] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!visible || !username) return;
+    setLoading(true);
+    Promise.all([
+      fetchUserProgress(username).then(setProgress),
+      getDoc(doc(db, 'usernames', username)).then(snap => {
+        if (snap.exists()) {
+          const data = snap.data();
+          setEmail(data.email || null);
+          setCountry(data.country || null);
+        }
+      })
+    ]).finally(() => setLoading(false));
+  }, [username, visible]);
+
+  const countryObj = countries.find(c => c.code === country);
+
+  return (
+    <Modal visible={visible} animationType="fade" transparent onRequestClose={onClose}>
+      <View style={styles.overlay}>
+        <View style={styles.card}>
+          {loading ? (
+            <ActivityIndicator color={theme.colors.accent} size="large" />
+          ) : (
+            <ScrollView contentContainerStyle={{ alignItems: 'center' }}>
+              <Text style={styles.title}>{t(uiLanguage, 'profile')}</Text>
+              <View style={styles.userBox}>
+                <Text style={styles.username}>{username}</Text>
+                {email && <Text style={styles.email}>{email}</Text>}
+              </View>
+              {countryObj && (
+                <View style={styles.countryBox}>
+                  <Text style={styles.flag}>{countryObj.flag}</Text>
+                  <Text style={styles.country}>{countryObj.name}</Text>
+                </View>
+              )}
+              <Text style={styles.section}>{t(uiLanguage, 'languagesLevels')}</Text>
+              <View style={styles.progressBox}>
+                {Object.keys(progress).length > 0 ? (
+                  Object.entries(progress).map(([lang, level]) => (
+                    <View key={lang} style={styles.langCard}>
+                      <Text style={styles.langName}>{(lang as string).toUpperCase()}</Text>
+                      <Text style={styles.levels}>
+                        {t(uiLanguage, 'countryLevel')}: {Array.isArray(level) ? level.join(', ') : String(level)}
+                      </Text>
+                    </View>
+                  ))
+                ) : (
+                  <Text style={styles.levels}>{t(uiLanguage, 'noProgress')}</Text>
+                )}
+              </View>
+            </ScrollView>
+          )}
+          <TouchableOpacity style={styles.closeButtonBox} onPress={onClose} activeOpacity={0.8}>
+            <Text style={styles.closeButtonText}>{t(uiLanguage, 'close')}</Text>
+          </TouchableOpacity>
+        </View>
+      </View>
+    </Modal>
+  );
+}
+
+const styles = StyleSheet.create({
+  overlay: {
+    flex: 1,
+    backgroundColor: theme.colors.overlay,
+    justifyContent: 'center',
+    alignItems: 'center',
+  },
+  card: {
+    width: 300,
+    backgroundColor: theme.colors.card,
+    borderRadius: 18,
+    padding: 20,
+    alignItems: 'center',
+    shadowColor: '#000',
+    shadowOpacity: 0.18,
+    shadowRadius: 10,
+    elevation: 6,
+  },
+  title: {
+    fontSize: 22,
+    fontWeight: 'bold',
+    color: theme.colors.accent,
+    marginBottom: 8,
+    letterSpacing: 0.5,
+  },
+  userBox: {
+    alignItems: 'center',
+    marginBottom: 4,
+  },
+  username: {
+    fontSize: 17,
+    fontWeight: '600',
+    color: theme.colors.text,
+  },
+  email: {
+    fontSize: 13,
+    color: '#bbb',
+    marginTop: 1,
+  },
+  countryBox: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: theme.colors.card,
+    borderRadius: 8,
+    paddingHorizontal: 10,
+    paddingVertical: 2,
+    marginVertical: 6,
+  },
+  flag: {
+    fontSize: 18,
+    marginRight: 6,
+  },
+  country: {
+    fontSize: 14,
+    color: theme.colors.text,
+  },
+  section: {
+    fontSize: 15,
+    color: theme.colors.accent,
+    fontWeight: 'bold',
+    marginTop: 14,
+    marginBottom: 4,
+    alignSelf: 'flex-start',
+  },
+  progressBox: {
+    width: '100%',
+    marginTop: 2,
+  },
+  langCard: {
+    backgroundColor: theme.colors.card,
+    borderRadius: 7,
+    padding: 6,
+    marginBottom: 5,
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  langName: {
+    color: theme.colors.text,
+    fontWeight: 'bold',
+    fontSize: 13,
+  },
+  levels: {
+    color: theme.colors.accent,
+    fontSize: 12,
+  },
+  closeButtonBox: {
+    marginTop: 14,
+    width: '100%',
+    alignItems: 'center',
+    backgroundColor: theme.colors.primary,
+    borderRadius: 8,
+  },
+  closeButtonText: {
+    color: theme.colors.text,
+    fontWeight: 'bold',
+    fontSize: 15,
+    paddingVertical: 7,
+    paddingHorizontal: 0,
+    textAlign: 'center',
+    width: '100%',
+  },
+});

--- a/translations.ts
+++ b/translations.ts
@@ -52,6 +52,7 @@ export const translations: Record<Lang, Record<string, string>> = {
     accept: 'Kabul Et',
     requestSent: 'İstek gönderildi',
     friendRequestFrom: 'Arkadaşlık isteği:',
+    viewProfile: 'Profili Gör',
   },
   en: {
     loginTitle: 'Login',
@@ -104,6 +105,7 @@ export const translations: Record<Lang, Record<string, string>> = {
     accept: 'Accept',
     requestSent: 'Request sent',
     friendRequestFrom: 'Friend request from',
+    viewProfile: 'View Profile',
   },
 };
 


### PR DESCRIPTION
## Summary
- enable viewing a friend's profile
- support new `viewProfile` translation text

## Testing
- `npm test` *(fails: `jest` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e1cd83fe0832681cd296e6cd965dc