### PR TITLE
Add new UX features

### DIFF
--- a/components/AuthScreen.tsx
+++ b/components/AuthScreen.tsx
@@ -20,6 +20,7 @@ export default function AuthScreen({
   const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [showPassword, setShowPassword] = useState(false);
   const [isRegister, setIsRegister] = useState(false);
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
@@ -106,14 +107,25 @@ export default function AuthScreen({
             </View>
           </>
         )}
-        <TextInput
-          style={styles.input}
-          placeholder={t(uiLanguage, 'password')}
-          value={password}
-          onChangeText={setPassword}
-          secureTextEntry
-          placeholderTextColor="#888"
-        />
+        <View style={styles.passwordRow}>
+          <TextInput
+            style={[styles.input, { flex: 1 }]}
+            placeholder={t(uiLanguage, 'password')}
+            value={password}
+            onChangeText={setPassword}
+            secureTextEntry={!showPassword}
+            placeholderTextColor="#888"
+          />
+          <TouchableOpacity
+            onPress={() => setShowPassword(!showPassword)}
+            style={styles.showButton}
+            activeOpacity={0.7}
+          >
+            <Text style={styles.showButtonText}>
+              {showPassword ? t(uiLanguage, 'hidePassword') : t(uiLanguage, 'showPassword')}
+            </Text>
+          </TouchableOpacity>
+        </View>
         {error ? <Text style={styles.error}>{error}</Text> : null}
         <View style={styles.buttonRow}>
           <TouchableOpacity
@@ -219,6 +231,23 @@ const styles = StyleSheet.create({
     letterSpacing: 0.5,
     paddingHorizontal: 8,
     paddingVertical: 2,
+  },
+  passwordRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    marginBottom: 14,
+    width: 240,
+  },
+  showButton: {
+    marginLeft: 8,
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    backgroundColor: theme.colors.primary,
+    borderRadius: 6,
+  },
+  showButtonText: {
+    color: theme.colors.text,
+    fontWeight: 'bold',
   },
   pickerBox: { width: 240, marginBottom: 14, backgroundColor: theme.colors.card, borderRadius: 8 },
   picker: { color: theme.colors.text, width: 240, height: 44 },

--- a/components/ProfileScreen.tsx
+++ b/components/ProfileScreen.tsx
@@ -147,6 +147,9 @@ export default function ProfileScreen({ onClose, visible, uiLanguage, onShowFrie
         <TouchableOpacity style={styles.friendButtonBox} onPress={onShowFriends} activeOpacity={0.8}>
           <Text style={styles.closeButtonText}>{t(uiLanguage, 'friends')}</Text>
         </TouchableOpacity>
+        <TouchableOpacity style={styles.closeButtonBox} onPress={async () => { await auth.signOut(); onClose(); }} activeOpacity={0.8}>
+          <Text style={styles.closeButtonText}>{t(uiLanguage, 'logout')}</Text>
+        </TouchableOpacity>
         <TouchableOpacity style={styles.closeButtonBox} onPress={onClose} activeOpacity={0.8}>
           <Text style={styles.closeButtonText}>{t(uiLanguage, 'close')}</Text>
         </TouchableOpacity>

--- a/components/Snippet.tsx
+++ b/components/Snippet.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { View, Text, StyleSheet, TouchableOpacity, Dimensions } from 'react-native';
+import { View, Text, StyleSheet, TouchableOpacity, Dimensions, Vibration } from 'react-native';
 import { Lang, t } from '../translations';
 
 export const Snippet = ({
@@ -41,6 +41,7 @@ export const Snippet = ({
     setSelectedAnswer(answer);
     setShowExplanation(true);
     setTimerActive(false);
+    Vibration.vibrate(answer ? 80 : 300);
   };
 
   const handleContinue = () => {

--- a/translations.ts
+++ b/translations.ts
@@ -56,6 +56,9 @@ export const translations: Record<Lang, Record<string, string>> = {
     badges: 'Rozetler',
     uploadPhoto: 'Fotoğraf Yükle',
     changePhoto: 'Fotoğrafı Değiştir',
+    logout: 'Çıkış Yap',
+    showPassword: 'Göster',
+    hidePassword: 'Gizle',
   },
   en: {
     loginTitle: 'Login',
@@ -112,6 +115,9 @@ export const translations: Record<Lang, Record<string, string>> = {
     badges: 'Badges',
     uploadPhoto: 'Upload Photo',
     changePhoto: 'Change Photo',
+    logout: 'Logout',
+    showPassword: 'Show',
+    hidePassword: 'Hide',
   },
 };
 


### PR DESCRIPTION
## Summary
- add ability to toggle password visibility on auth screen
- allow user to sign out from profile screen
- vibrate device when answering snippets
- extend translations for new strings

## Testing
- `npx tsc --noEmit` *(fails: Cannot find module 'react', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_687e24344f4c8326b5267cd8e353a9b3