### PR TITLE
Improve UI buttons and password field

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -164,7 +164,7 @@ export default function App() {
 
   // Profilim butonu her ekranda aktif
   const ProfileButton = (
-    <View style={{ position: 'absolute', top: 40, right: 24, zIndex: 30 }}>
+    <View style={{ position: 'absolute', bottom: 40, right: 24, zIndex: 30 }}>
       <TouchableOpacity style={[styles.gameOverButton, { minWidth: 110, paddingVertical: 8, paddingHorizontal: 16 }]} onPress={() => setShowProfile(true)} activeOpacity={0.7}>
         <Text style={styles.gameOverButtonText}>{t(uiLanguage, 'myProfile')}</Text>
       </TouchableOpacity>
@@ -550,31 +550,31 @@ const styles = StyleSheet.create({
   },
   leaderboardButton: {
     backgroundColor: theme.colors.primary,
-    borderRadius: 8,
-    paddingVertical: 12,
-    paddingHorizontal: 28,
+    borderRadius: 12,
+    paddingVertical: 14,
+    paddingHorizontal: 32,
     alignItems: 'center',
     marginHorizontal: 8,
-    elevation: 2,
+    elevation: 3,
     borderWidth: 1.5,
     borderColor: '#005bb5',
     shadowColor: '#000',
-    shadowOpacity: 0.12,
-    shadowRadius: 4,
+    shadowOpacity: 0.2,
+    shadowRadius: 6,
   },
   gameOverButton: {
     backgroundColor: theme.colors.primary,
-    borderRadius: 8,
-    paddingVertical: 12,
-    paddingHorizontal: 24,
+    borderRadius: 12,
+    paddingVertical: 14,
+    paddingHorizontal: 28,
     alignItems: 'center',
     marginHorizontal: 8,
-    elevation: 2,
+    elevation: 3,
     borderWidth: 1.5,
     borderColor: '#005bb5',
     shadowColor: '#000',
-    shadowOpacity: 0.12,
-    shadowRadius: 4,
+    shadowOpacity: 0.2,
+    shadowRadius: 6,
     minWidth: 120,
   },
   gameOverButtonText: {

--- a/components/AuthScreen.tsx
+++ b/components/AuthScreen.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, StyleSheet, TouchableOpacity } from 'react-native';
+import Icon from 'react-native-vector-icons/Ionicons';
 import { theme } from '../theme';
 import { Picker } from '@react-native-picker/picker';
 import { registerWithUsername, loginWithUsername } from '../systems/auth';
@@ -107,9 +108,9 @@ export default function AuthScreen({
             </View>
           </>
         )}
-        <View style={styles.passwordRow}>
+        <View style={styles.inputWrapper}>
           <TextInput
-            style={[styles.input, { flex: 1 }]}
+            style={[styles.input, { paddingRight: 40 }]}
             placeholder={t(uiLanguage, 'password')}
             value={password}
             onChangeText={setPassword}
@@ -118,12 +119,14 @@ export default function AuthScreen({
           />
           <TouchableOpacity
             onPress={() => setShowPassword(!showPassword)}
-            style={styles.showButton}
+            style={styles.eyeIcon}
             activeOpacity={0.7}
           >
-            <Text style={styles.showButtonText}>
-              {showPassword ? t(uiLanguage, 'hidePassword') : t(uiLanguage, 'showPassword')}
-            </Text>
+            <Icon
+              name={showPassword ? 'eye-off' : 'eye'}
+              size={20}
+              color={theme.colors.text}
+            />
           </TouchableOpacity>
         </View>
         {error ? <Text style={styles.error}>{error}</Text> : null}
@@ -216,12 +219,16 @@ const styles = StyleSheet.create({
   },
   authButton: {
     backgroundColor: theme.colors.primary,
-    borderRadius: 8,
+    borderRadius: 12,
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
     marginHorizontal: 8,
-    height: 44,
+    height: 48,
+    shadowColor: '#000',
+    shadowOpacity: 0.2,
+    shadowRadius: 4,
+    elevation: 3,
   },
   buttonText: {
     color: theme.colors.text,
@@ -232,22 +239,16 @@ const styles = StyleSheet.create({
     paddingHorizontal: 8,
     paddingVertical: 2,
   },
-  passwordRow: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    marginBottom: 14,
+  inputWrapper: {
+    position: 'relative',
     width: 240,
+    marginBottom: 14,
   },
-  showButton: {
-    marginLeft: 8,
-    paddingVertical: 6,
-    paddingHorizontal: 8,
-    backgroundColor: theme.colors.primary,
-    borderRadius: 6,
-  },
-  showButtonText: {
-    color: theme.colors.text,
-    fontWeight: 'bold',
+  eyeIcon: {
+    position: 'absolute',
+    right: 12,
+    top: '50%',
+    marginTop: -10,
   },
   pickerBox: { width: 240, marginBottom: 14, backgroundColor: theme.colors.card, borderRadius: 8 },
   picker: { color: theme.colors.text, width: 240, height: 44 },


### PR DESCRIPTION
## Summary
- modernize auth and game buttons
- move profile button to bottom right of the screen
- replace password toggle with eye icon inside the input

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e2fe478c08326a51d34d56bd8cea4