### PR TITLE
Add leaderboard button to profile and fix home page

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -220,7 +220,17 @@ export default function App() {
         />
         {showProfile && (
           <View style={[styles.leaderboardModal, { zIndex: 40 }]}> {/* Modal gibi üstte */}
-            <ProfileScreen visible={showProfile} onClose={() => setShowProfile(false)} uiLanguage={uiLanguage} onShowFriends={() => { setShowFriends(true); setShowProfile(false); }} selectedLanguage={selectedLanguage} />
+            <ProfileScreen
+              visible={showProfile}
+              onClose={() => setShowProfile(false)}
+              uiLanguage={uiLanguage}
+              onShowFriends={() => {
+                setShowFriends(true);
+                setShowProfile(false);
+              }}
+              selectedLanguage={selectedLanguage}
+              onShowLeaderboard={() => setShowLeaderboardLangSelect(true)}
+            />
             <TouchableOpacity style={styles.gameOverButton} onPress={() => setShowProfile(false)} activeOpacity={0.7}>
               <Text style={styles.gameOverButtonText}>{t(uiLanguage, 'close')}</Text>
             </TouchableOpacity>
@@ -250,6 +260,18 @@ export default function App() {
             </TouchableOpacity>
           </View>
         )}
+        {showLeaderboardLangSelect && (
+          <LeaderboardLanguageModal
+            visible={showLeaderboardLangSelect}
+            uiLanguage={uiLanguage}
+            onSelect={(lang) => {
+              setLeaderboardLanguage(lang);
+              setShowLeaderboard(true);
+              setShowLeaderboardLangSelect(false);
+            }}
+            onClose={() => setShowLeaderboardLangSelect(false)}
+          />
+        )}
         {Footer}
       </View>
     );
@@ -262,7 +284,17 @@ export default function App() {
         <Text style={{ color: 'white', marginTop: 20 }}>{t(uiLanguage, 'loadingQuestions')}</Text>
         {showProfile && (
           <View style={[styles.leaderboardModal, { zIndex: 40 }]}> {/* Modal gibi üstte */}
-            <ProfileScreen visible={showProfile} onClose={() => setShowProfile(false)} uiLanguage={uiLanguage} onShowFriends={() => { setShowFriends(true); setShowProfile(false); }} selectedLanguage={selectedLanguage} />
+            <ProfileScreen
+              visible={showProfile}
+              onClose={() => setShowProfile(false)}
+              uiLanguage={uiLanguage}
+              onShowFriends={() => {
+                setShowFriends(true);
+                setShowProfile(false);
+              }}
+              selectedLanguage={selectedLanguage}
+              onShowLeaderboard={() => setShowLeaderboardLangSelect(true)}
+            />
             <TouchableOpacity style={styles.gameOverButton} onPress={() => setShowProfile(false)} activeOpacity={0.7}>
               <Text style={styles.gameOverButtonText}>{t(uiLanguage, 'close')}</Text>
             </TouchableOpacity>
@@ -280,7 +312,17 @@ export default function App() {
         <Button title={t(uiLanguage, 'tryAgain')} onPress={() => handleLanguageSelect(selectedLanguage!)} />
         {showProfile && (
           <View style={[styles.leaderboardModal, { zIndex: 40 }]}> {/* Modal gibi üstte */}
-            <ProfileScreen visible={showProfile} onClose={() => setShowProfile(false)} uiLanguage={uiLanguage} onShowFriends={() => { setShowFriends(true); setShowProfile(false); }} selectedLanguage={selectedLanguage} />
+            <ProfileScreen
+              visible={showProfile}
+              onClose={() => setShowProfile(false)}
+              uiLanguage={uiLanguage}
+              onShowFriends={() => {
+                setShowFriends(true);
+                setShowProfile(false);
+              }}
+              selectedLanguage={selectedLanguage}
+              onShowLeaderboard={() => setShowLeaderboardLangSelect(true)}
+            />
             <TouchableOpacity style={styles.gameOverButton} onPress={() => setShowProfile(false)} activeOpacity={0.7}>
               <Text style={styles.gameOverButtonText}>{t(uiLanguage, 'close')}</Text>
             </TouchableOpacity>
@@ -387,7 +429,17 @@ export default function App() {
       )}
       {showProfile && (
         <View style={[styles.leaderboardModal, { zIndex: 20 }]}> {/* Modal gibi üstte */}
-          <ProfileScreen visible={showProfile} onClose={() => setShowProfile(false)} uiLanguage={uiLanguage} onShowFriends={() => { setShowFriends(true); setShowProfile(false); }} selectedLanguage={selectedLanguage} />
+          <ProfileScreen
+            visible={showProfile}
+            onClose={() => setShowProfile(false)}
+            uiLanguage={uiLanguage}
+            onShowFriends={() => {
+              setShowFriends(true);
+              setShowProfile(false);
+            }}
+            selectedLanguage={selectedLanguage}
+            onShowLeaderboard={() => setShowLeaderboardLangSelect(true)}
+          />
           <TouchableOpacity style={styles.gameOverButton} onPress={() => setShowProfile(false)} activeOpacity={0.7}>
             <Text style={styles.gameOverButtonText}>{t(uiLanguage, 'close')}</Text>
           </TouchableOpacity>

--- a/components/ProfileScreen.tsx
+++ b/components/ProfileScreen.tsx
@@ -10,7 +10,7 @@ import { doc, getDoc } from 'firebase/firestore';
 import { db } from '../firebaseConfig';
 import { countries } from './countries';
 
-export default function ProfileScreen({ onClose, visible, uiLanguage, onShowFriends, selectedLanguage }: { onClose: () => void; visible: boolean; uiLanguage: Lang; onShowFriends: () => void; selectedLanguage: string | null }) {
+export default function ProfileScreen({ onClose, visible, uiLanguage, onShowFriends, selectedLanguage, onShowLeaderboard }: { onClose: () => void; visible: boolean; uiLanguage: Lang; onShowFriends: () => void; selectedLanguage: string | null; onShowLeaderboard: () => void }) {
   const [progress, setProgress] = useState<any>(null);
   const [loading, setLoading] = useState(true);
   const [country, setCountry] = useState<string | null>(null);
@@ -178,6 +178,9 @@ export default function ProfileScreen({ onClose, visible, uiLanguage, onShowFrie
         <TouchableOpacity style={styles.friendButtonBox} onPress={onShowFriends} activeOpacity={0.8}>
           <Text style={styles.closeButtonText}>{t(uiLanguage, 'friends')}</Text>
         </TouchableOpacity>
+        <TouchableOpacity style={styles.leaderboardButton} onPress={onShowLeaderboard} activeOpacity={0.8}>
+          <Text style={styles.closeButtonText}>{t(uiLanguage, 'leaderboard')}</Text>
+        </TouchableOpacity>
         <TouchableOpacity style={styles.closeButtonBox} onPress={async () => { await auth.signOut(); onClose(); }} activeOpacity={0.8}>
           <Text style={styles.closeButtonText}>{t(uiLanguage, 'logout')}</Text>
         </TouchableOpacity>
@@ -328,6 +331,21 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     backgroundColor: theme.colors.primary,
     borderRadius: 8,
+  },
+  leaderboardButton: {
+    backgroundColor: theme.colors.primary,
+    borderRadius: 12,
+    paddingVertical: 14,
+    paddingHorizontal: 32,
+    alignItems: 'center',
+    marginTop: 12,
+    elevation: 3,
+    borderWidth: 1.5,
+    borderColor: '#005bb5',
+    shadowColor: '#000',
+    shadowOpacity: 0.2,
+    shadowRadius: 6,
+    width: '100%',
   },
   closeButtonBox: {
     marginTop: 14,


### PR DESCRIPTION
## Summary
- add leaderboard button on profile screen
- wire up onShowLeaderboard prop for ProfileScreen
- show leaderboard modal on home page

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687e3b4bd8f883268c36ccb08ab9b2d0