### PR TITLE
Add theme selection with dark mode

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,9 +1,10 @@
-import React, { useState, useRef, useEffect } from 'react';
+import React, { useState, useRef, useEffect, useMemo } from 'react';
 import { StyleSheet, View, Text, Button, ActivityIndicator, TouchableOpacity } from 'react-native';
-import { theme } from './theme';
+import { useTheme } from './theme';
 import { GameEngine } from 'react-native-game-engine';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { LanguageSelector } from './components/LanguageSelector';
+import ThemeSelector from './components/ThemeSelector';
 import { hackSystem } from './systems/hack';
 import { fetchSnippets } from './systems/fetchSnippets';
 import AuthScreen from './components/AuthScreen';
@@ -16,6 +17,8 @@ import { Lang, t } from './translations';
 import { subscribeFriendRequests } from './systems/friends';
 
 export default function App() {
+  const { theme, setMode } = useTheme();
+  const [themeSelected, setThemeSelected] = useState(false);
   const [selectedLanguage, setSelectedLanguage] = useState<string | null>(null);
   const [uiLanguage, setUiLanguage] = useState<Lang>('tr');
   const [score, setScore] = useState(0);
@@ -41,6 +44,7 @@ export default function App() {
   const [pendingRequests, setPendingRequests] = useState<any[]>([]);
   const [notification, setNotification] = useState<string | null>(null);
   const gameEngineRef = useRef<any>(null);
+  const styles = React.useMemo(() => createStyles(theme), [theme]);
 
   useEffect(() => {
     AsyncStorage.getItem('bestScore').then(value => {
@@ -200,6 +204,10 @@ export default function App() {
       </TouchableOpacity>
     </View>
   );
+
+  if (!themeSelected) {
+    return <ThemeSelector onSelect={(m) => { setMode(m); setThemeSelected(true); }} uiLanguage={uiLanguage} />;
+  }
 
   if (!user) {
       return (
@@ -417,7 +425,7 @@ export default function App() {
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (theme: any) => StyleSheet.create({
   container: { flex: 1, backgroundColor: theme.colors.background },
   gameContainer: { flex: 1 },
   overlay: {

--- a/components/AuthScreen.tsx
+++ b/components/AuthScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, StyleSheet, TouchableOpacity } from 'react-native';
-import { theme } from '../theme';
+import { useTheme } from '../theme';
 import { Picker } from '@react-native-picker/picker';
 import { registerWithUsername, loginWithUsername } from '../systems/auth';
 import { updateProfile } from 'firebase/auth';
@@ -17,6 +17,7 @@ export default function AuthScreen({
   onLanguageChange: (lang: Lang) => void;
 
 }) {
+  const { theme } = useTheme();
   const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -52,6 +53,96 @@ export default function AuthScreen({
       setLoading(false);
     }
   };
+
+  const styles = React.useMemo(
+    () =>
+      StyleSheet.create({
+        authContainer: {
+          flex: 1,
+          backgroundColor: theme.colors.background,
+          justifyContent: 'center',
+          alignItems: 'center',
+        },
+        langRow: {
+          flexDirection: 'row',
+          marginBottom: 12,
+          gap: 10,
+        },
+        langButton: {
+          backgroundColor: theme.colors.card,
+          paddingVertical: 8,
+          paddingHorizontal: 16,
+          borderRadius: 8,
+        },
+        langButtonActive: {
+          backgroundColor: theme.colors.primary,
+        },
+        langButtonText: { color: theme.colors.text, fontWeight: 'bold' },
+        authBox: {
+          backgroundColor: theme.colors.card,
+          borderRadius: 20,
+          padding: 32,
+          width: 320,
+          alignItems: 'center',
+          shadowColor: '#000',
+          shadowOpacity: 0.1,
+          shadowRadius: 12,
+          elevation: 6,
+        },
+        title: {
+          color: theme.colors.accent,
+          fontSize: 28,
+          fontWeight: 'bold',
+          marginBottom: 18,
+          letterSpacing: 1,
+        },
+        input: {
+          backgroundColor: theme.colors.card,
+          color: theme.colors.text,
+          borderRadius: 12,
+          padding: 12,
+          marginBottom: 16,
+          width: 260,
+          fontSize: 16,
+          borderWidth: 1,
+          borderColor: theme.colors.border,
+          shadowColor: '#000',
+          shadowOpacity: 0.05,
+          shadowRadius: 2,
+          elevation: 1,
+        },
+        error: { color: theme.colors.error, marginBottom: 10 },
+        success: { color: theme.colors.success, marginBottom: 10, fontWeight: 'bold' },
+        buttonRow: {
+          flexDirection: 'row',
+          marginTop: 8,
+          width: '100%',
+          justifyContent: 'space-between',
+          gap: 0,
+        },
+        authButton: {
+          backgroundColor: theme.colors.primary,
+          borderRadius: 12,
+          flex: 1,
+          alignItems: 'center',
+          justifyContent: 'center',
+          marginHorizontal: 8,
+          height: 48,
+        },
+        buttonText: {
+          color: theme.colors.text,
+          fontWeight: 'bold',
+          fontSize: 16,
+          textAlign: 'center',
+          letterSpacing: 0.5,
+          paddingHorizontal: 8,
+          paddingVertical: 2,
+        },
+        pickerBox: { width: 240, marginBottom: 14, backgroundColor: theme.colors.card, borderRadius: 8 },
+        picker: { color: theme.colors.text, width: 240, height: 44 },
+      }),
+    [theme]
+  );
 
   return (
     <View style={[styles.authContainer, { backgroundColor: theme.colors.background }]}>
@@ -138,88 +229,3 @@ export default function AuthScreen({
   );
 }
 
-const styles = StyleSheet.create({
-  authContainer: {
-    flex: 1,
-    backgroundColor: theme.colors.background,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  langRow: {
-    flexDirection: 'row',
-    marginBottom: 12,
-    gap: 10,
-  },
-  langButton: {
-    backgroundColor: theme.colors.card,
-    paddingVertical: 8,
-    paddingHorizontal: 16,
-    borderRadius: 8,
-  },
-  langButtonActive: {
-    backgroundColor: theme.colors.primary,
-  },
-  langButtonText: { color: theme.colors.text, fontWeight: 'bold' },
-  authBox: {
-    backgroundColor: theme.colors.card,
-    borderRadius: 20,
-    padding: 32,
-    width: 320,
-    alignItems: 'center',
-    shadowColor: '#000',
-    shadowOpacity: 0.1,
-    shadowRadius: 12,
-    elevation: 6,
-  },
-  title: {
-    color: theme.colors.accent,
-    fontSize: 28,
-    fontWeight: 'bold',
-    marginBottom: 18,
-    letterSpacing: 1,
-  },
-  input: {
-    backgroundColor: theme.colors.card,
-    color: theme.colors.text,
-    borderRadius: 12,
-    padding: 12,
-    marginBottom: 16,
-    width: 260,
-    fontSize: 16,
-    borderWidth: 1,
-    borderColor: theme.colors.border,
-    shadowColor: '#000',
-    shadowOpacity: 0.05,
-    shadowRadius: 2,
-    elevation: 1,
-  },
-  error: { color: theme.colors.error, marginBottom: 10 },
-  success: { color: theme.colors.success, marginBottom: 10, fontWeight: 'bold' },
-  buttonRow: {
-    flexDirection: 'row',
-    marginTop: 8,
-    width: '100%',
-    justifyContent: 'space-between',
-    gap: 0,
-  },
-  authButton: {
-    backgroundColor: theme.colors.primary,
-    borderRadius: 12,
-    flex: 1,
-    alignItems: 'center',
-    justifyContent: 'center',
-    marginHorizontal: 8,
-    height: 48,
-  },
-  buttonText: {
-    color: theme.colors.text,
-    fontWeight: 'bold',
-    fontSize: 16,
-    textAlign: 'center',
-    letterSpacing: 0.5,
-    paddingHorizontal: 8,
-    paddingVertical: 2,
-  },
-  pickerBox: { width: 240, marginBottom: 14, backgroundColor: theme.colors.card, borderRadius: 8 },
-  picker: { color: theme.colors.text, width: 240, height: 44 },
-});

--- a/components/FriendsScreen.tsx
+++ b/components/FriendsScreen.tsx
@@ -1,12 +1,13 @@
 import React, { useState, useEffect } from 'react';
 import { Modal, View, Text, StyleSheet, TextInput, TouchableOpacity, ActivityIndicator, ScrollView } from 'react-native';
-import { theme } from '../theme';
+import { useTheme } from '../theme';
 import { Lang, t } from '../translations';
 import { auth } from '../systems/auth';
 import { searchUsers, sendFriendRequest, fetchFriendRequests, fetchSentFriendRequests, acceptFriendRequest, fetchFriendsWithProgress } from '../systems/friends';
 import UserProfileScreen from './UserProfileScreen';
 
 export default function FriendsScreen({ visible, onClose, uiLanguage }: { visible: boolean; onClose: () => void; uiLanguage: Lang }) {
+  const { theme } = useTheme();
   const user = auth.currentUser;
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<any[]>([]);
@@ -57,10 +58,98 @@ export default function FriendsScreen({ visible, onClose, uiLanguage }: { visibl
     });
   };
 
+  const styles = React.useMemo(
+    () =>
+      StyleSheet.create({
+        overlay: {
+          flex: 1,
+          backgroundColor: theme.colors.overlay,
+          justifyContent: 'center',
+          alignItems: 'center',
+        },
+        card: {
+          width: 320,
+          backgroundColor: theme.colors.card,
+          borderRadius: 20,
+          padding: 24,
+          alignItems: 'center',
+        },
+        title: {
+          color: theme.colors.accent,
+          fontSize: 22,
+          fontWeight: 'bold',
+          marginBottom: 8,
+        },
+        searchRow: { flexDirection: 'row', marginBottom: 8 },
+        input: {
+          backgroundColor: theme.colors.card,
+          color: theme.colors.text,
+          borderRadius: 12,
+          borderWidth: 1,
+          borderColor: theme.colors.border,
+          paddingHorizontal: 10,
+          paddingVertical: 8,
+          flex: 1,
+          marginRight: 6,
+        },
+        searchButton: {
+          backgroundColor: theme.colors.primary,
+          borderRadius: 12,
+          paddingHorizontal: 12,
+          justifyContent: 'center',
+        },
+        addButton: {
+          backgroundColor: theme.colors.primary,
+          borderRadius: 12,
+          paddingHorizontal: 12,
+          paddingVertical: 6,
+        },
+        profileButton: {
+          backgroundColor: theme.colors.primary,
+          borderRadius: 12,
+          paddingHorizontal: 12,
+          paddingVertical: 6,
+          marginLeft: 6,
+        },
+        buttonText: { color: theme.colors.text, fontWeight: 'bold' },
+        row: {
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+          paddingVertical: 4,
+          width: '100%',
+        },
+        name: { color: theme.colors.text, fontSize: 15, flex: 1 },
+        levelText: {
+          color: theme.colors.accent,
+          fontSize: 12,
+          flex: 1,
+          textAlign: 'right',
+        },
+        section: {
+          alignSelf: 'flex-start',
+          marginTop: 10,
+          marginBottom: 4,
+          color: theme.colors.accent,
+          fontWeight: 'bold',
+        },
+        closeButton: {
+          marginTop: 12,
+          backgroundColor: theme.colors.primary,
+          borderRadius: 12,
+          paddingVertical: 10,
+          paddingHorizontal: 24,
+        },
+        info: { color: theme.colors.success, marginBottom: 6, fontWeight: 'bold' },
+        sentText: { color: theme.colors.accent, fontWeight: 'bold' },
+      }),
+    [theme]
+  );
+
   return (
     <>
-    <Modal visible={visible} animationType="fade" transparent onRequestClose={onClose}>
-      <View style={styles.overlay}>
+      <Modal visible={visible} animationType="fade" transparent onRequestClose={onClose}>
+        <View style={styles.overlay}>
         <View style={styles.card}>
           <Text style={styles.title}>{t(uiLanguage, 'friends')}</Text>
           {info && <Text style={styles.info}>{info}</Text>}
@@ -145,103 +234,3 @@ export default function FriendsScreen({ visible, onClose, uiLanguage }: { visibl
   );
 }
 
-const styles = StyleSheet.create({
-  overlay: {
-    flex: 1,
-    backgroundColor: theme.colors.overlay,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  card: {
-    width: 320,
-    backgroundColor: theme.colors.card,
-    borderRadius: 20,
-    padding: 24,
-    alignItems: 'center',
-  },
-  title: {
-    color: theme.colors.accent,
-    fontSize: 22,
-    fontWeight: 'bold',
-    marginBottom: 8,
-  },
-  searchRow: {
-    flexDirection: 'row',
-    marginBottom: 8,
-  },
-  input: {
-    backgroundColor: theme.colors.card,
-    color: theme.colors.text,
-    borderRadius: 12,
-    borderWidth: 1,
-    borderColor: theme.colors.border,
-    paddingHorizontal: 10,
-    paddingVertical: 8,
-    flex: 1,
-    marginRight: 6,
-  },
-  searchButton: {
-    backgroundColor: theme.colors.primary,
-    borderRadius: 12,
-    paddingHorizontal: 12,
-    justifyContent: 'center',
-  },
-  addButton: {
-    backgroundColor: theme.colors.primary,
-    borderRadius: 12,
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-  },
-  profileButton: {
-    backgroundColor: theme.colors.primary,
-    borderRadius: 12,
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    marginLeft: 6,
-  },
-  buttonText: {
-    color: theme.colors.text,
-    fontWeight: 'bold',
-  },
-  row: {
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-    paddingVertical: 4,
-    width: '100%',
-  },
-  name: {
-    color: theme.colors.text,
-    fontSize: 15,
-    flex: 1,
-  },
-  levelText: {
-    color: theme.colors.accent,
-    fontSize: 12,
-    flex: 1,
-    textAlign: 'right',
-  },
-  section: {
-    alignSelf: 'flex-start',
-    marginTop: 10,
-    marginBottom: 4,
-    color: theme.colors.accent,
-    fontWeight: 'bold',
-  },
-  closeButton: {
-    marginTop: 12,
-    backgroundColor: theme.colors.primary,
-    borderRadius: 12,
-    paddingVertical: 10,
-    paddingHorizontal: 24,
-  },
-  info: {
-    color: theme.colors.success,
-    marginBottom: 6,
-    fontWeight: 'bold',
-  },
-  sentText: {
-    color: theme.colors.accent,
-    fontWeight: 'bold',
-  },
-});

--- a/components/LanguageSelector.tsx
+++ b/components/LanguageSelector.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
-import { theme } from '../theme';
+import { useTheme } from '../theme';
 import { Lang, t } from '../translations';
 
 export const LanguageSelector = ({
@@ -11,6 +11,7 @@ export const LanguageSelector = ({
   uiLanguage: Lang;
 
 }) => {
+  const { theme } = useTheme();
   const [language, setLanguage] = useState<string | null>(null);
   const [showReady, setShowReady] = useState(false);
 
@@ -19,11 +20,65 @@ export const LanguageSelector = ({
     setShowReady(true);
   };
 
+
   const handleStart = () => {
     if (language) {
       onSelect(language);
     }
   };
+
+  const styles = React.useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          flex: 1,
+          backgroundColor: theme.colors.background,
+          justifyContent: 'center',
+          alignItems: 'center',
+        },
+        title: {
+          color: theme.colors.accent,
+          fontSize: 24,
+          marginBottom: 30,
+          fontWeight: 'bold',
+          textAlign: 'center',
+        },
+        buttonGrid: {
+          gap: 20,
+        },
+        buttonRow: {
+          flexDirection: 'column',
+          justifyContent: 'center',
+          marginBottom: 10,
+          gap: 20,
+          alignItems: 'center',
+        },
+        button: {
+          backgroundColor: theme.colors.card,
+          paddingVertical: 16,
+          paddingHorizontal: 32,
+          borderRadius: 12,
+          marginHorizontal: 10,
+        },
+        readyButton: {
+          backgroundColor: theme.colors.primary,
+          paddingVertical: 16,
+          paddingHorizontal: 48,
+          borderRadius: 12,
+          marginTop: 20,
+        },
+        buttonText: {
+          color: theme.colors.text,
+          fontSize: 18,
+          fontWeight: 'bold',
+        },
+        levelLocked: {
+          opacity: 0.5,
+        },
+        row: { flexDirection: 'row', gap: 20, marginBottom: 20 },
+      }),
+    [theme]
+  );
 
   if (showReady && language) {
     return (
@@ -57,55 +112,7 @@ export const LanguageSelector = ({
           </TouchableOpacity>
         </View>
       </View>
-      {/* Theme selection removed */}
+      
     </View>
   );
 };
-
-const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-    backgroundColor: theme.colors.background,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  title: {
-    color: theme.colors.accent,
-    fontSize: 24,
-    marginBottom: 30,
-    fontWeight: 'bold',
-    textAlign: 'center',
-  },
-  buttonGrid: {
-    gap: 20,
-  },
-  buttonRow: {
-    flexDirection: 'column', // alt alta
-    justifyContent: 'center',
-    marginBottom: 10,
-    gap: 20,
-    alignItems: 'center',
-  },
-  button: {
-    backgroundColor: theme.colors.card,
-    paddingVertical: 16,
-    paddingHorizontal: 32,
-    borderRadius: 12,
-    marginHorizontal: 10,
-  },
-  readyButton: {
-    backgroundColor: theme.colors.primary,
-    paddingVertical: 16,
-    paddingHorizontal: 48,
-    borderRadius: 12,
-    marginTop: 20,
-  },
-  buttonText: {
-    color: theme.colors.text,
-    fontSize: 18,
-    fontWeight: 'bold',
-  },
-  levelLocked: {
-    opacity: 0.5,
-  },
-});

--- a/components/NotificationBanner.tsx
+++ b/components/NotificationBanner.tsx
@@ -1,31 +1,35 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { theme } from '../theme';
+import { useTheme } from '../theme';
 
 export default function NotificationBanner({ message }: { message: string | null }) {
+  const { theme } = useTheme();
   if (!message) return null;
+  const styles = React.useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          position: 'absolute',
+          top: 40,
+          left: 20,
+          right: 20,
+          backgroundColor: theme.colors.primary,
+          borderRadius: 12,
+          paddingVertical: 10,
+          paddingHorizontal: 16,
+          zIndex: 100,
+        },
+        text: {
+          color: theme.colors.text,
+          fontWeight: 'bold',
+          textAlign: 'center',
+        },
+      }),
+    [theme]
+  );
   return (
     <View style={styles.container} pointerEvents="none">
       <Text style={styles.text}>{message}</Text>
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    position: 'absolute',
-    top: 40,
-    left: 20,
-    right: 20,
-    backgroundColor: theme.colors.primary,
-    borderRadius: 12,
-    paddingVertical: 10,
-    paddingHorizontal: 16,
-    zIndex: 100,
-  },
-  text: {
-    color: theme.colors.text,
-    fontWeight: 'bold',
-    textAlign: 'center',
-  },
-});

--- a/components/ProfileScreen.tsx
+++ b/components/ProfileScreen.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Modal, View, Text, StyleSheet, ActivityIndicator, ScrollView, TouchableOpacity, Image } from 'react-native';
 import { launchImageLibrary } from 'react-native-image-picker';
 import { updateProfile } from 'firebase/auth';
-import { theme } from '../theme';
+import { useTheme } from '../theme';
 import { Lang, t } from '../translations';
 import { auth } from '../systems/auth';
 import { fetchUserProgress } from '../systems/leaderboard';
@@ -11,6 +11,7 @@ import { db } from '../firebaseConfig';
 import { countries } from './countries';
 
 export default function ProfileScreen({ onClose, visible, uiLanguage, onShowFriends }: { onClose: () => void, visible: boolean, uiLanguage: Lang, onShowFriends: () => void }) {
+  const { theme } = useTheme();
   const [progress, setProgress] = useState<any>(null);
   const [loading, setLoading] = useState(true);
   const [country, setCountry] = useState<string | null>(null);
@@ -82,6 +83,115 @@ export default function ProfileScreen({ onClose, visible, uiLanguage, onShowFrie
   }
 
   let countryObj = countries.find(c => c.code === country);
+
+  const styles = React.useMemo(
+    () =>
+      StyleSheet.create({
+        overlay: {
+          flex: 1,
+          backgroundColor: theme.colors.overlay,
+          justifyContent: 'center',
+          alignItems: 'center',
+        },
+        card: {
+          width: 300,
+          backgroundColor: theme.colors.card,
+          borderRadius: 20,
+          padding: 24,
+          alignItems: 'center',
+          shadowColor: '#000',
+          shadowOpacity: 0.1,
+          shadowRadius: 8,
+          elevation: 4,
+        },
+        title: {
+          fontSize: 22,
+          fontWeight: 'bold',
+          color: theme.colors.accent,
+          marginBottom: 8,
+          letterSpacing: 0.5,
+        },
+        userBox: { alignItems: 'center', marginBottom: 4 },
+        username: { fontSize: 17, fontWeight: '600', color: theme.colors.text },
+        email: { fontSize: 13, color: '#bbb', marginTop: 1 },
+        countryBox: {
+          flexDirection: 'row',
+          alignItems: 'center',
+          backgroundColor: theme.colors.card,
+          borderRadius: 12,
+          paddingHorizontal: 12,
+          paddingVertical: 4,
+          marginVertical: 6,
+        },
+        flag: { fontSize: 18, marginRight: 6 },
+        country: { fontSize: 14, color: theme.colors.text },
+        section: {
+          fontSize: 15,
+          color: theme.colors.accent,
+          fontWeight: 'bold',
+          marginTop: 14,
+          marginBottom: 4,
+          alignSelf: 'flex-start',
+        },
+        progressBox: { width: '100%', marginTop: 2 },
+        langCard: {
+          backgroundColor: theme.colors.card,
+          borderRadius: 7,
+          padding: 6,
+          marginBottom: 5,
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        },
+        langName: { color: theme.colors.text, fontWeight: 'bold', fontSize: 13 },
+        levels: { color: theme.colors.accent, fontSize: 12 },
+        avatar: { width: 80, height: 80, borderRadius: 40, marginBottom: 8 },
+        photoButton: {
+          backgroundColor: theme.colors.primary,
+          borderRadius: 12,
+          paddingHorizontal: 12,
+          paddingVertical: 6,
+          marginBottom: 8,
+        },
+        photoButtonText: { color: theme.colors.text, fontWeight: 'bold' },
+        badgesBox: { flexDirection: 'row', flexWrap: 'wrap', marginBottom: 8 },
+        badge: {
+          backgroundColor: theme.colors.primary,
+          color: theme.colors.text,
+          paddingHorizontal: 8,
+          paddingVertical: 2,
+          borderRadius: 8,
+          marginRight: 4,
+          marginBottom: 4,
+          fontSize: 12,
+        },
+        friendButtonBox: {
+          marginTop: 12,
+          width: '100%',
+          alignItems: 'center',
+          backgroundColor: theme.colors.primary,
+          borderRadius: 12,
+        },
+        closeButtonBox: {
+          marginTop: 14,
+          width: '100%',
+          alignItems: 'center',
+          backgroundColor: theme.colors.primary,
+          borderRadius: 12,
+        },
+        closeButtonText: {
+          color: theme.colors.text,
+          fontWeight: 'bold',
+          fontSize: 15,
+          paddingVertical: 7,
+          paddingHorizontal: 0,
+          textAlign: 'center',
+          width: '100%',
+        },
+        info: { color: '#bbb', fontSize: 15, textAlign: 'center', marginVertical: 8 },
+      }),
+    [theme]
+  );
 
   return (
     <Modal
@@ -156,151 +266,3 @@ export default function ProfileScreen({ onClose, visible, uiLanguage, onShowFrie
   );
 }
 
-const styles = StyleSheet.create({
-  overlay: {
-    flex: 1,
-    backgroundColor: theme.colors.overlay,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  card: {
-    width: 300,
-    backgroundColor: theme.colors.card,
-    borderRadius: 20,
-    padding: 24,
-    alignItems: 'center',
-    shadowColor: '#000',
-    shadowOpacity: 0.1,
-    shadowRadius: 8,
-    elevation: 4,
-  },
-  title: {
-    fontSize: 22,
-    fontWeight: 'bold',
-    color: theme.colors.accent,
-    marginBottom: 8,
-    letterSpacing: 0.5,
-  },
-  userBox: {
-    alignItems: 'center',
-    marginBottom: 4,
-  },
-  username: {
-    fontSize: 17,
-    fontWeight: '600',
-    color: theme.colors.text,
-  },
-  email: {
-    fontSize: 13,
-    color: '#bbb',
-    marginTop: 1,
-  },
-  countryBox: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: theme.colors.card,
-    borderRadius: 12,
-    paddingHorizontal: 12,
-    paddingVertical: 4,
-    marginVertical: 6,
-  },
-  flag: {
-    fontSize: 18,
-    marginRight: 6,
-  },
-  country: {
-    fontSize: 14,
-    color: theme.colors.text,
-  },
-  section: {
-    fontSize: 15,
-    color: theme.colors.accent,
-    fontWeight: 'bold',
-    marginTop: 14,
-    marginBottom: 4,
-    alignSelf: 'flex-start',
-  },
-  progressBox: {
-    width: '100%',
-    marginTop: 2,
-  },
-  langCard: {
-    backgroundColor: theme.colors.card,
-    borderRadius: 7,
-    padding: 6,
-    marginBottom: 5,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  langName: {
-    color: theme.colors.text,
-    fontWeight: 'bold',
-    fontSize: 13,
-  },
-  levels: {
-    color: theme.colors.accent,
-    fontSize: 12,
-  },
-  avatar: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    marginBottom: 8,
-  },
-  photoButton: {
-    backgroundColor: theme.colors.primary,
-    borderRadius: 12,
-    paddingHorizontal: 12,
-    paddingVertical: 6,
-    marginBottom: 8,
-  },
-  photoButtonText: {
-    color: theme.colors.text,
-    fontWeight: 'bold',
-  },
-  badgesBox: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    marginBottom: 8,
-  },
-  badge: {
-    backgroundColor: theme.colors.primary,
-    color: theme.colors.text,
-    paddingHorizontal: 8,
-    paddingVertical: 2,
-    borderRadius: 8,
-    marginRight: 4,
-    marginBottom: 4,
-    fontSize: 12,
-  },
-  friendButtonBox: {
-    marginTop: 12,
-    width: '100%',
-    alignItems: 'center',
-    backgroundColor: theme.colors.primary,
-    borderRadius: 12,
-  },
-  closeButtonBox: {
-    marginTop: 14,
-    width: '100%',
-    alignItems: 'center',
-    backgroundColor: theme.colors.primary,
-    borderRadius: 12,
-  },
-  closeButtonText: {
-    color: theme.colors.text,
-    fontWeight: 'bold',
-    fontSize: 15,
-    paddingVertical: 7,
-    paddingHorizontal: 0,
-    textAlign: 'center',
-    width: '100%',
-  },
-  info: {
-    color: '#bbb',
-    fontSize: 15,
-    textAlign: 'center',
-    marginVertical: 8,
-  },
-});

--- a/components/ThemeSelector.tsx
+++ b/components/ThemeSelector.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
+import { useTheme, ThemeMode } from '../theme';
+import { Lang, t } from '../translations';
+
+export default function ThemeSelector({
+  onSelect,
+  uiLanguage,
+}: {
+  onSelect: (mode: ThemeMode) => void;
+  uiLanguage: Lang;
+}) {
+  const { theme } = useTheme();
+  const styles = React.useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          flex: 1,
+          backgroundColor: theme.colors.background,
+          justifyContent: 'center',
+          alignItems: 'center',
+        },
+        title: {
+          color: theme.colors.accent,
+          fontSize: 24,
+          marginBottom: 30,
+          fontWeight: 'bold',
+          textAlign: 'center',
+        },
+        row: { flexDirection: 'row', gap: 20 },
+        button: {
+          backgroundColor: theme.colors.card,
+          paddingVertical: 16,
+          paddingHorizontal: 32,
+          borderRadius: 12,
+        },
+        buttonText: {
+          color: theme.colors.text,
+          fontSize: 18,
+          fontWeight: 'bold',
+        },
+      }),
+    [theme]
+  );
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>{t(uiLanguage, 'selectTheme')}</Text>
+      <View style={styles.row}>
+        <TouchableOpacity style={styles.button} onPress={() => onSelect('light')}>
+          <Text style={styles.buttonText}>{t(uiLanguage, 'light')}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.button} onPress={() => onSelect('dark')}>
+          <Text style={styles.buttonText}>{t(uiLanguage, 'dark')}</Text>
+        </TouchableOpacity>
+      </View>
+    </View>
+  );
+}

--- a/components/UserProfileScreen.tsx
+++ b/components/UserProfileScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 import { Modal, View, Text, StyleSheet, ActivityIndicator, ScrollView, TouchableOpacity, Image } from 'react-native';
-import { theme } from '../theme';
+import { useTheme } from '../theme';
 import { Lang, t } from '../translations';
 import { fetchUserProgress } from '../systems/leaderboard';
 import { doc, getDoc } from 'firebase/firestore';
@@ -8,6 +8,7 @@ import { db } from '../firebaseConfig';
 import { countries } from './countries';
 
 export default function UserProfileScreen({ visible, onClose, username, uiLanguage }: { visible: boolean; onClose: () => void; username: string; uiLanguage: Lang }) {
+  const { theme } = useTheme();
   const [progress, setProgress] = useState<any>({});
   const [loading, setLoading] = useState(true);
   const [email, setEmail] = useState<string | null>(null);
@@ -31,6 +32,99 @@ export default function UserProfileScreen({ visible, onClose, username, uiLangua
   }, [username, visible]);
 
   const countryObj = countries.find(c => c.code === country);
+
+  const styles = React.useMemo(
+    () =>
+      StyleSheet.create({
+        overlay: {
+          flex: 1,
+          backgroundColor: theme.colors.overlay,
+          justifyContent: 'center',
+          alignItems: 'center',
+        },
+        card: {
+          width: 300,
+          backgroundColor: theme.colors.card,
+          borderRadius: 18,
+          padding: 20,
+          alignItems: 'center',
+          shadowColor: '#000',
+          shadowOpacity: 0.18,
+          shadowRadius: 10,
+          elevation: 6,
+        },
+        title: {
+          fontSize: 22,
+          fontWeight: 'bold',
+          color: theme.colors.accent,
+          marginBottom: 8,
+          letterSpacing: 0.5,
+        },
+        userBox: { alignItems: 'center', marginBottom: 4 },
+        username: { fontSize: 17, fontWeight: '600', color: theme.colors.text },
+        email: { fontSize: 13, color: '#bbb', marginTop: 1 },
+        countryBox: {
+          flexDirection: 'row',
+          alignItems: 'center',
+          backgroundColor: theme.colors.card,
+          borderRadius: 8,
+          paddingHorizontal: 10,
+          paddingVertical: 2,
+          marginVertical: 6,
+        },
+        flag: { fontSize: 18, marginRight: 6 },
+        country: { fontSize: 14, color: theme.colors.text },
+        section: {
+          fontSize: 15,
+          color: theme.colors.accent,
+          fontWeight: 'bold',
+          marginTop: 14,
+          marginBottom: 4,
+          alignSelf: 'flex-start',
+        },
+        progressBox: { width: '100%', marginTop: 2 },
+        langCard: {
+          backgroundColor: theme.colors.card,
+          borderRadius: 7,
+          padding: 6,
+          marginBottom: 5,
+          flexDirection: 'row',
+          justifyContent: 'space-between',
+          alignItems: 'center',
+        },
+        langName: { color: theme.colors.text, fontWeight: 'bold', fontSize: 13 },
+        levels: { color: theme.colors.accent, fontSize: 12 },
+        avatar: { width: 80, height: 80, borderRadius: 40, marginBottom: 8 },
+        badgesBox: { flexDirection: 'row', flexWrap: 'wrap', marginBottom: 8 },
+        badge: {
+          backgroundColor: theme.colors.primary,
+          color: theme.colors.text,
+          paddingHorizontal: 8,
+          paddingVertical: 2,
+          borderRadius: 6,
+          marginRight: 4,
+          marginBottom: 4,
+          fontSize: 12,
+        },
+        closeButtonBox: {
+          marginTop: 14,
+          width: '100%',
+          alignItems: 'center',
+          backgroundColor: theme.colors.primary,
+          borderRadius: 8,
+        },
+        closeButtonText: {
+          color: theme.colors.text,
+          fontWeight: 'bold',
+          fontSize: 15,
+          paddingVertical: 7,
+          paddingHorizontal: 0,
+          textAlign: 'center',
+          width: '100%',
+        },
+      }),
+    [theme]
+  );
 
   return (
     <Modal visible={visible} animationType="fade" transparent onRequestClose={onClose}>
@@ -97,127 +191,3 @@ export default function UserProfileScreen({ visible, onClose, username, uiLangua
   );
 }
 
-const styles = StyleSheet.create({
-  overlay: {
-    flex: 1,
-    backgroundColor: theme.colors.overlay,
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  card: {
-    width: 300,
-    backgroundColor: theme.colors.card,
-    borderRadius: 18,
-    padding: 20,
-    alignItems: 'center',
-    shadowColor: '#000',
-    shadowOpacity: 0.18,
-    shadowRadius: 10,
-    elevation: 6,
-  },
-  title: {
-    fontSize: 22,
-    fontWeight: 'bold',
-    color: theme.colors.accent,
-    marginBottom: 8,
-    letterSpacing: 0.5,
-  },
-  userBox: {
-    alignItems: 'center',
-    marginBottom: 4,
-  },
-  username: {
-    fontSize: 17,
-    fontWeight: '600',
-    color: theme.colors.text,
-  },
-  email: {
-    fontSize: 13,
-    color: '#bbb',
-    marginTop: 1,
-  },
-  countryBox: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: theme.colors.card,
-    borderRadius: 8,
-    paddingHorizontal: 10,
-    paddingVertical: 2,
-    marginVertical: 6,
-  },
-  flag: {
-    fontSize: 18,
-    marginRight: 6,
-  },
-  country: {
-    fontSize: 14,
-    color: theme.colors.text,
-  },
-  section: {
-    fontSize: 15,
-    color: theme.colors.accent,
-    fontWeight: 'bold',
-    marginTop: 14,
-    marginBottom: 4,
-    alignSelf: 'flex-start',
-  },
-  progressBox: {
-    width: '100%',
-    marginTop: 2,
-  },
-  langCard: {
-    backgroundColor: theme.colors.card,
-    borderRadius: 7,
-    padding: 6,
-    marginBottom: 5,
-    flexDirection: 'row',
-    justifyContent: 'space-between',
-    alignItems: 'center',
-  },
-  langName: {
-    color: theme.colors.text,
-    fontWeight: 'bold',
-    fontSize: 13,
-  },
-  levels: {
-    color: theme.colors.accent,
-    fontSize: 12,
-  },
-  avatar: {
-    width: 80,
-    height: 80,
-    borderRadius: 40,
-    marginBottom: 8,
-  },
-  badgesBox: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    marginBottom: 8,
-  },
-  badge: {
-    backgroundColor: theme.colors.primary,
-    color: theme.colors.text,
-    paddingHorizontal: 8,
-    paddingVertical: 2,
-    borderRadius: 6,
-    marginRight: 4,
-    marginBottom: 4,
-    fontSize: 12,
-  },
-  closeButtonBox: {
-    marginTop: 14,
-    width: '100%',
-    alignItems: 'center',
-    backgroundColor: theme.colors.primary,
-    borderRadius: 8,
-  },
-  closeButtonText: {
-    color: theme.colors.text,
-    fontWeight: 'bold',
-    fontSize: 15,
-    paddingVertical: 7,
-    paddingHorizontal: 0,
-    textAlign: 'center',
-    width: '100%',
-  },
-});

--- a/index.js
+++ b/index.js
@@ -4,6 +4,13 @@
 
 import { AppRegistry } from 'react-native';
 import App from './App';
+import { ThemeProvider } from './theme';
 import { name as appName } from './app.json';
 
-AppRegistry.registerComponent(appName, () => App);
+const Root = () => (
+  <ThemeProvider>
+    <App />
+  </ThemeProvider>
+);
+
+AppRegistry.registerComponent(appName, () => Root);

--- a/theme.ts
+++ b/theme.ts
@@ -1,12 +1,24 @@
-export const theme = {
+import React, { createContext, useContext, useEffect, useState } from 'react';
+import AsyncStorage from '@react-native-async-storage/async-storage';
+
+export type ThemeMode = 'light' | 'dark';
+
+export interface Theme {
   colors: {
-    /**
-     * A lighter and more modern color palette.
-     * The previous colors were very dark which
-     * made the UI feel dated. These new tones
-     * brighten the interface and improve
-     * readability across all screens.
-     */
+    background: string;
+    card: string;
+    primary: string;
+    text: string;
+    accent: string;
+    error: string;
+    success: string;
+    border: string;
+    overlay: string;
+  };
+}
+
+const lightTheme: Theme = {
+  colors: {
     background: '#f0f2f5',
     card: '#ffffff',
     primary: '#6200ee',
@@ -17,4 +29,55 @@ export const theme = {
     border: '#e0e0e0',
     overlay: 'rgba(0,0,0,0.5)',
   },
+};
+
+const darkTheme: Theme = {
+  colors: {
+    background: '#121212',
+    card: '#1e1e1e',
+    primary: '#bb86fc',
+    text: '#ffffff',
+    accent: '#03dac6',
+    error: '#cf6679',
+    success: '#4caf50',
+    border: '#272727',
+    overlay: 'rgba(0,0,0,0.7)',
+  },
+};
+
+interface ThemeContextValue {
+  theme: Theme;
+  setMode: (mode: ThemeMode) => void;
+}
+
+const ThemeContext = createContext<ThemeContextValue>({
+  theme: lightTheme,
+  setMode: () => {},
+});
+
+export const useTheme = () => useContext(ThemeContext);
+
+export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
+  const [mode, setMode] = useState<ThemeMode>('light');
+
+  useEffect(() => {
+    AsyncStorage.getItem('themeMode').then(value => {
+      if (value === 'dark' || value === 'light') {
+        setMode(value);
+      }
+    });
+  }, []);
+
+  const handleSetMode = (m: ThemeMode) => {
+    setMode(m);
+    AsyncStorage.setItem('themeMode', m);
+  };
+
+  const theme = mode === 'dark' ? darkTheme : lightTheme;
+
+  return (
+    <ThemeContext.Provider value={{ theme, setMode: handleSetMode }}>
+      {children}
+    </ThemeContext.Provider>
+  );
 };

--- a/translations.ts
+++ b/translations.ts
@@ -61,6 +61,9 @@ export const translations: Record<Lang, Record<string, string>> = {
     paused: 'Duraklatıldı',
     streak: 'Seri',
     bestStreak: 'En İyi Seri',
+    selectTheme: 'Tema Seç',
+    light: 'Açık',
+    dark: 'Karanlık',
   },
   en: {
     loginTitle: 'Login',
@@ -122,6 +125,9 @@ export const translations: Record<Lang, Record<string, string>> = {
     paused: 'Paused',
     streak: 'Streak',
     bestStreak: 'Best Streak',
+    selectTheme: 'Select Theme',
+    light: 'Light',
+    dark: 'Dark',
   },
 };
 


### PR DESCRIPTION
## Summary
- add light and dark themes with ThemeProvider
- create ThemeSelector component for choosing theme
- update UI components to use dynamic theming
- integrate theme selection flow in the app entry

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f69dba8208326a73605bf89e09648