### PR TITLE
Add theme toggle on login and context provider

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useRef, useEffect } from 'react';
 import { StyleSheet, View, Text, Button, ActivityIndicator, TouchableOpacity } from 'react-native';
-import { theme } from './theme';
+import { ThemeProvider, useTheme, Theme } from './theme';
 import { GameEngine } from 'react-native-game-engine';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { LanguageSelector } from './components/LanguageSelector';
@@ -15,7 +15,7 @@ import NotificationBanner from './components/NotificationBanner';
 import { Lang, t } from './translations';
 import { subscribeFriendRequests } from './systems/friends';
 
-export default function App() {
+function MainApp() {
   const [selectedLanguage, setSelectedLanguage] = useState<string | null>(null);
   const [uiLanguage, setUiLanguage] = useState<Lang>('tr');
   const [score, setScore] = useState(0);
@@ -38,6 +38,8 @@ export default function App() {
   const [pendingRequests, setPendingRequests] = useState<any[]>([]);
   const [notification, setNotification] = useState<string | null>(null);
   const gameEngineRef = useRef<any>(null);
+  const { theme } = useTheme();
+  const styles = React.useMemo(() => createStyles(theme), [theme]);
 
   useEffect(() => {
     AsyncStorage.getItem('bestScore').then(value => {
@@ -370,7 +372,7 @@ export default function App() {
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (theme: Theme) => StyleSheet.create({
   container: { flex: 1, backgroundColor: theme.colors.background },
   gameContainer: { flex: 1 },
   overlay: {
@@ -585,3 +587,11 @@ const styles = StyleSheet.create({
     textAlign: 'center',
   },
 });
+
+export default function App() {
+  return (
+    <ThemeProvider>
+      <MainApp />
+    </ThemeProvider>
+  );
+}

--- a/components/AuthScreen.tsx
+++ b/components/AuthScreen.tsx
@@ -1,6 +1,7 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { View, Text, TextInput, StyleSheet, TouchableOpacity } from 'react-native';
-import { theme } from '../theme';
+import { useTheme, darkTheme } from '../theme';
+import Ionicons from '@expo/vector-icons/Ionicons';
 import { Picker } from '@react-native-picker/picker';
 import { registerWithUsername, loginWithUsername } from '../systems/auth';
 import { updateProfile } from 'firebase/auth';
@@ -25,6 +26,9 @@ export default function AuthScreen({
   const [loading, setLoading] = useState(false);
   const [registerSuccess, setRegisterSuccess] = useState(false);
   const [country, setCountry] = useState('TR');
+
+  const { theme, toggleTheme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
 
 
   const handleSubmit = async () => {
@@ -67,6 +71,13 @@ export default function AuthScreen({
           onPress={() => onLanguageChange('en')}
         >
           <Text style={styles.langButtonText}>EN</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.themeButton} onPress={toggleTheme}>
+          {theme === darkTheme ? (
+            <Ionicons name="sunny" size={20} color={theme.colors.text} />
+          ) : (
+            <Ionicons name="moon" size={20} color={theme.colors.text} />
+          )}
         </TouchableOpacity>
       </View>
       <View style={styles.authBox}>
@@ -138,7 +149,7 @@ export default function AuthScreen({
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (theme: any) => StyleSheet.create({
   authContainer: {
     flex: 1,
     backgroundColor: theme.colors.background,
@@ -158,6 +169,12 @@ const styles = StyleSheet.create({
   },
   langButtonActive: {
     backgroundColor: theme.colors.primary,
+  },
+  themeButton: {
+    backgroundColor: theme.colors.card,
+    paddingVertical: 6,
+    paddingHorizontal: 8,
+    borderRadius: 6,
   },
   langButtonText: { color: theme.colors.text, fontWeight: 'bold' },
   authBox: {

--- a/components/FriendsScreen.tsx
+++ b/components/FriendsScreen.tsx
@@ -1,6 +1,6 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useMemo } from 'react';
 import { Modal, View, Text, StyleSheet, TextInput, TouchableOpacity, ActivityIndicator, ScrollView } from 'react-native';
-import { theme } from '../theme';
+import { useTheme } from '../theme';
 import { Lang, t } from '../translations';
 import { auth } from '../systems/auth';
 import { searchUsers, sendFriendRequest, fetchFriendRequests, fetchSentFriendRequests, acceptFriendRequest, fetchFriendsWithProgress } from '../systems/friends';
@@ -17,6 +17,9 @@ export default function FriendsScreen({ visible, onClose, uiLanguage }: { visibl
   const [sentRequests, setSentRequests] = useState<string[]>([]);
   const [outgoingRequests, setOutgoingRequests] = useState<any[]>([]);
   const [selectedFriend, setSelectedFriend] = useState<string | null>(null);
+
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
 
   useEffect(() => {
     if (visible && user?.displayName) {
@@ -145,7 +148,7 @@ export default function FriendsScreen({ visible, onClose, uiLanguage }: { visibl
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (theme: any) => StyleSheet.create({
   overlay: {
     flex: 1,
     backgroundColor: theme.colors.overlay,

--- a/components/LanguageSelector.tsx
+++ b/components/LanguageSelector.tsx
@@ -1,6 +1,6 @@
-import React, { useState } from 'react';
+import React, { useState, useMemo } from 'react';
 import { View, Text, TouchableOpacity, StyleSheet } from 'react-native';
-import { theme } from '../theme';
+import { useTheme } from '../theme';
 import { Lang, t } from '../translations';
 
 export const LanguageSelector = ({
@@ -13,6 +13,8 @@ export const LanguageSelector = ({
 }) => {
   const [language, setLanguage] = useState<string | null>(null);
   const [showReady, setShowReady] = useState(false);
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
 
   const handleLanguage = (lang: string) => {
     setLanguage(lang);
@@ -62,7 +64,7 @@ export const LanguageSelector = ({
   );
 };
 
-const styles = StyleSheet.create({
+const createStyles = (theme: any) => StyleSheet.create({
   container: {
     flex: 1,
     backgroundColor: theme.colors.background,

--- a/components/NotificationBanner.tsx
+++ b/components/NotificationBanner.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 import { View, Text, StyleSheet } from 'react-native';
-import { theme } from '../theme';
+import { useTheme } from '../theme';
 
 export default function NotificationBanner({ message }: { message: string | null }) {
+  const { theme } = useTheme();
+  const styles = React.useMemo(() => createStyles(theme), [theme]);
   if (!message) return null;
   return (
     <View style={styles.container} pointerEvents="none">
@@ -11,7 +13,7 @@ export default function NotificationBanner({ message }: { message: string | null
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (theme: any) => StyleSheet.create({
   container: {
     position: 'absolute',
     top: 40,

--- a/components/ProfileScreen.tsx
+++ b/components/ProfileScreen.tsx
@@ -1,8 +1,8 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { Modal, View, Text, StyleSheet, ActivityIndicator, ScrollView, TouchableOpacity, Image } from 'react-native';
 import { launchImageLibrary } from 'react-native-image-picker';
 import { updateProfile } from 'firebase/auth';
-import { theme } from '../theme';
+import { useTheme } from '../theme';
 import { Lang, t } from '../translations';
 import { auth } from '../systems/auth';
 import { fetchUserProgress } from '../systems/leaderboard';
@@ -16,6 +16,8 @@ export default function ProfileScreen({ onClose, visible, uiLanguage, onShowFrie
   const [country, setCountry] = useState<string | null>(null);
   const [photo, setPhoto] = useState<string | null>(user?.photoURL ?? null);
   const user = auth.currentUser;
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
 
   useEffect(() => {
     if (user?.displayName) {
@@ -156,7 +158,7 @@ export default function ProfileScreen({ onClose, visible, uiLanguage, onShowFrie
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (theme: any) => StyleSheet.create({
   overlay: {
     flex: 1,
     backgroundColor: theme.colors.overlay,

--- a/components/UserProfileScreen.tsx
+++ b/components/UserProfileScreen.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useState, useMemo } from 'react';
 import { Modal, View, Text, StyleSheet, ActivityIndicator, ScrollView, TouchableOpacity, Image } from 'react-native';
-import { theme } from '../theme';
+import { useTheme } from '../theme';
 import { Lang, t } from '../translations';
 import { fetchUserProgress } from '../systems/leaderboard';
 import { doc, getDoc } from 'firebase/firestore';
@@ -13,6 +13,8 @@ export default function UserProfileScreen({ visible, onClose, username, uiLangua
   const [email, setEmail] = useState<string | null>(null);
   const [country, setCountry] = useState<string | null>(null);
   const [photo, setPhoto] = useState<string | null>(null);
+  const { theme } = useTheme();
+  const styles = useMemo(() => createStyles(theme), [theme]);
 
   useEffect(() => {
     if (!visible || !username) return;
@@ -97,7 +99,7 @@ export default function UserProfileScreen({ visible, onClose, username, uiLangua
   );
 }
 
-const styles = StyleSheet.create({
+const createStyles = (theme: any) => StyleSheet.create({
   overlay: {
     flex: 1,
     backgroundColor: theme.colors.overlay,

--- a/theme.ts
+++ b/theme.ts
@@ -1,4 +1,34 @@
-export const theme = {
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+export type Theme = {
+  colors: {
+    background: string;
+    card: string;
+    primary: string;
+    text: string;
+    accent: string;
+    error: string;
+    success: string;
+    border: string;
+    overlay: string;
+  };
+};
+
+export const lightTheme: Theme = {
+  colors: {
+    background: '#f2f2f2',
+    card: '#ffffff',
+    primary: '#0A84FF',
+    text: '#000000',
+    accent: '#007aff',
+    error: '#FF453A',
+    success: '#32D74B',
+    border: '#d0d0d0',
+    overlay: 'rgba(255,255,255,0.8)',
+  },
+};
+
+export const darkTheme: Theme = {
   colors: {
     background: '#121212',
     card: '#1f1f1f',
@@ -11,3 +41,21 @@ export const theme = {
     overlay: 'rgba(0,0,0,0.7)',
   },
 };
+
+const ThemeContext = createContext<{ theme: Theme; toggleTheme: () => void }>({
+  theme: darkTheme,
+  toggleTheme: () => {},
+});
+
+export const ThemeProvider = ({ children }: { children: ReactNode }) => {
+  const [theme, setTheme] = useState<Theme>(darkTheme);
+  const toggleTheme = () =>
+    setTheme((t) => (t === darkTheme ? lightTheme : darkTheme));
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+};
+
+export const useTheme = () => useContext(ThemeContext);


### PR DESCRIPTION
## Summary
- add light and dark theme support with `ThemeProvider`
- use theme context throughout the app
- show sun/moon button on the login screen to switch theme

## Testing
- `npm test` *(fails: jest not found)*
- `npx tsc --noEmit` *(fails: missing deps)*

------
https://chatgpt.com/codex/tasks/task_e_687f706264ac83268421e8cc68239d52