### PR TITLE
Add theme toggle to login screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -4,7 +4,6 @@ import { useTheme } from './theme';
 import { GameEngine } from 'react-native-game-engine';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 import { LanguageSelector } from './components/LanguageSelector';
-import ThemeSelector from './components/ThemeSelector';
 import { hackSystem } from './systems/hack';
 import { fetchSnippets } from './systems/fetchSnippets';
 import AuthScreen from './components/AuthScreen';
@@ -18,7 +17,6 @@ import { subscribeFriendRequests } from './systems/friends';
 
 export default function App() {
   const { theme } = useTheme();
-  const [themeSelected, setThemeSelected] = useState(false);
   const [selectedLanguage, setSelectedLanguage] = useState<string | null>(null);
   const [uiLanguage, setUiLanguage] = useState<Lang>('tr');
   const [score, setScore] = useState(0);
@@ -205,9 +203,6 @@ export default function App() {
     </View>
   );
 
-  if (!themeSelected) {
-    return <ThemeSelector onSelect={() => { setThemeSelected(true); }} uiLanguage={uiLanguage} />;
-  }
 
   if (!user) {
       return (

--- a/components/AuthScreen.tsx
+++ b/components/AuthScreen.tsx
@@ -17,7 +17,7 @@ export default function AuthScreen({
   onLanguageChange: (lang: Lang) => void;
 
 }) {
-  const { theme } = useTheme();
+  const { theme, setMode, mode } = useTheme();
   const [username, setUsername] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -26,6 +26,10 @@ export default function AuthScreen({
   const [loading, setLoading] = useState(false);
   const [registerSuccess, setRegisterSuccess] = useState(false);
   const [country, setCountry] = useState('TR');
+
+  const toggleTheme = () => {
+    setMode(mode === 'dark' ? 'light' : 'dark');
+  };
 
 
   const handleSubmit = async () => {
@@ -78,6 +82,13 @@ export default function AuthScreen({
           backgroundColor: theme.colors.primary,
         },
         langButtonText: { color: theme.colors.text, fontWeight: 'bold' },
+        themeButton: {
+          backgroundColor: theme.colors.card,
+          paddingVertical: 8,
+          paddingHorizontal: 12,
+          borderRadius: 8,
+        },
+        themeButtonText: { color: theme.colors.text, fontWeight: 'bold', fontSize: 18 },
         authBox: {
           backgroundColor: theme.colors.card,
           borderRadius: 20,
@@ -158,6 +169,12 @@ export default function AuthScreen({
           onPress={() => onLanguageChange('en')}
         >
           <Text style={styles.langButtonText}>EN</Text>
+        </TouchableOpacity>
+        <TouchableOpacity
+          style={styles.themeButton}
+          onPress={toggleTheme}
+        >
+          <Text style={styles.themeButtonText}>{mode === 'dark' ? '🌙' : '🌞'}</Text>
         </TouchableOpacity>
       </View>
       <View style={styles.authBox}>

--- a/theme.tsx
+++ b/theme.tsx
@@ -47,11 +47,13 @@ const darkTheme: Theme = {
 
 interface ThemeContextValue {
   theme: Theme;
+  mode: ThemeMode;
   setMode: (mode: ThemeMode) => void;
 }
 
 const ThemeContext = createContext<ThemeContextValue>({
   theme: lightTheme,
+  mode: 'light',
   setMode: () => {},
 });
 
@@ -76,7 +78,7 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
   const theme = mode === 'dark' ? darkTheme : lightTheme;
 
   return (
-    <ThemeContext.Provider value={{ theme, setMode: handleSetMode }}>
+    <ThemeContext.Provider value={{ theme, mode, setMode: handleSetMode }}>
       {children}
     </ThemeContext.Provider>
   );


### PR DESCRIPTION
## Summary
- drop startup theme selection screen
- expose current theme mode in context
- add sun/moon toggle button to login screen

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f76696c7883269f30cbfe0531a4f4