### PR TITLE
Implement XP-based level system

### DIFF
--- a/translations.ts
+++ b/translations.ts
@@ -56,6 +56,7 @@ export const translations: Record<Lang, Record<string, string>> = {
     badges: 'Rozetler',
     uploadPhoto: 'Fotoğraf Yükle',
     changePhoto: 'Fotoğrafı Değiştir',
+    xp: 'XP',
   },
   en: {
     loginTitle: 'Login',
@@ -112,6 +113,7 @@ export const translations: Record<Lang, Record<string, string>> = {
     badges: 'Badges',
     uploadPhoto: 'Upload Photo',
     changePhoto: 'Change Photo',
+    xp: 'XP',
   },
 };
 


### PR DESCRIPTION
## Summary
- add XP state and constants for leveling up
- update handleAnswer logic to grant XP and level up when XP reaches 100
- display XP progress bar and numeric XP in the UI
- reset XP on language select and game reset
- extend translations with `xp` label

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: missing ESLint config)*
- `npx tsc -p tsconfig.json` *(fails: TypeScript config errors)*

------
https://chatgpt.com/codex/tasks/task_e_687f90fd34ec83268643df2513019a57