### PR TITLE
Enhance game UI with retro theme

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -668,6 +668,7 @@ const createStyles = (theme: any) =>
       textShadowColor: '#000',
       textShadowOffset: { width: 0, height: 2 },
       textShadowRadius: 6,
+      fontFamily: theme.fontFamily,
     },
     finalScore: {
       fontSize: 22,
@@ -678,6 +679,7 @@ const createStyles = (theme: any) =>
       textShadowColor: '#000',
       textShadowOffset: { width: 0, height: 1 },
       textShadowRadius: 2,
+      fontFamily: theme.fontFamily,
     },
     levelBox: {
       alignSelf: 'center',
@@ -695,6 +697,7 @@ const createStyles = (theme: any) =>
       fontWeight: 'bold',
       textAlign: 'center',
       letterSpacing: 1,
+      fontFamily: theme.fontFamily,
     },
     infoBar: {
       flexDirection: 'row',
@@ -725,6 +728,7 @@ const createStyles = (theme: any) =>
       textShadowColor: '#000',
       textShadowOffset: { width: 0, height: 1 },
       textShadowRadius: 2,
+      fontFamily: theme.fontFamily,
     },
     infoValue: {
       color: theme.colors.text,
@@ -733,6 +737,7 @@ const createStyles = (theme: any) =>
       textShadowColor: '#000',
       textShadowOffset: { width: 0, height: 1 },
       textShadowRadius: 2,
+      fontFamily: theme.fontFamily,
     },
     levelSelectContainer: {
       flex: 1,
@@ -745,6 +750,7 @@ const createStyles = (theme: any) =>
       fontSize: 26,
       fontWeight: 'bold',
       marginBottom: 30,
+      fontFamily: theme.fontFamily,
     },
     levelItem: {
       width: 220,
@@ -779,6 +785,7 @@ const createStyles = (theme: any) =>
       fontWeight: 'bold',
       marginBottom: 18,
       letterSpacing: 1,
+      fontFamily: theme.fontFamily,
     },
     leaderboardHeader: {
       color: theme.colors.accent,
@@ -786,6 +793,7 @@ const createStyles = (theme: any) =>
       fontSize: 16,
       marginBottom: 2,
       textAlign: 'left',
+      fontFamily: theme.fontFamily,
     },
     leaderboardRow: {
       flexDirection: 'row',
@@ -803,6 +811,7 @@ const createStyles = (theme: any) =>
       width: 28,
       textAlign: 'right',
       fontWeight: 'bold',
+      fontFamily: theme.fontFamily,
     },
     leaderboardName: {
       color: theme.colors.text,
@@ -810,6 +819,7 @@ const createStyles = (theme: any) =>
       flex: 1,
       marginLeft: 10,
       fontWeight: 'bold',
+      fontFamily: theme.fontFamily,
     },
     leaderboardScore: {
       color: theme.colors.accent,
@@ -817,6 +827,7 @@ const createStyles = (theme: any) =>
       fontWeight: 'bold',
       width: 40,
       textAlign: 'right',
+      fontFamily: theme.fontFamily,
     },
     leaderboardButton: {
       backgroundColor: theme.colors.primary,
@@ -853,5 +864,6 @@ const createStyles = (theme: any) =>
       fontSize: 16,
       letterSpacing: 0.5,
       textAlign: 'center',
+      fontFamily: theme.fontFamily,
     },
   });

--- a/components/AuthScreen.tsx
+++ b/components/AuthScreen.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { View, Text, TextInput, StyleSheet, TouchableOpacity } from 'react-native';
-import { useTheme } from '../theme';
+import { useTheme, ThemeMode } from '../theme';
 import { Picker } from '@react-native-picker/picker';
 import { registerWithUsername, loginWithUsername } from '../systems/auth';
 import { updateProfile } from 'firebase/auth';
@@ -28,7 +28,9 @@ export default function AuthScreen({
   const [country, setCountry] = useState('TR');
 
   const toggleTheme = () => {
-    setMode(mode === 'dark' ? 'light' : 'dark');
+    const modes: ThemeMode[] = ['light', 'dark', 'retro'];
+    const next = (modes.indexOf(mode) + 1) % modes.length;
+    setMode(modes[next]);
   };
 
 
@@ -81,14 +83,23 @@ export default function AuthScreen({
         langButtonActive: {
           backgroundColor: theme.colors.primary,
         },
-        langButtonText: { color: theme.colors.text, fontWeight: 'bold' },
+        langButtonText: {
+          color: theme.colors.text,
+          fontWeight: 'bold',
+          fontFamily: theme.fontFamily,
+        },
         themeButton: {
           backgroundColor: theme.colors.card,
           paddingVertical: 8,
           paddingHorizontal: 12,
           borderRadius: 8,
         },
-        themeButtonText: { color: theme.colors.text, fontWeight: 'bold', fontSize: 18 },
+        themeButtonText: {
+          color: theme.colors.text,
+          fontWeight: 'bold',
+          fontSize: 18,
+          fontFamily: theme.fontFamily,
+        },
         authBox: {
           backgroundColor: theme.colors.card,
           borderRadius: 20,
@@ -106,6 +117,7 @@ export default function AuthScreen({
           fontWeight: 'bold',
           marginBottom: 18,
           letterSpacing: 1,
+          fontFamily: theme.fontFamily,
         },
         input: {
           backgroundColor: theme.colors.card,
@@ -121,9 +133,19 @@ export default function AuthScreen({
           shadowOpacity: 0.05,
           shadowRadius: 2,
           elevation: 1,
+          fontFamily: theme.fontFamily,
         },
-        error: { color: theme.colors.error, marginBottom: 10 },
-        success: { color: theme.colors.success, marginBottom: 10, fontWeight: 'bold' },
+        error: {
+          color: theme.colors.error,
+          marginBottom: 10,
+          fontFamily: theme.fontFamily,
+        },
+        success: {
+          color: theme.colors.success,
+          marginBottom: 10,
+          fontWeight: 'bold',
+          fontFamily: theme.fontFamily,
+        },
         buttonRow: {
           flexDirection: 'row',
           marginTop: 8,
@@ -148,6 +170,7 @@ export default function AuthScreen({
           letterSpacing: 0.5,
           paddingHorizontal: 8,
           paddingVertical: 2,
+          fontFamily: theme.fontFamily,
         },
         pickerBox: { width: 240, marginBottom: 14, backgroundColor: theme.colors.card, borderRadius: 8 },
         picker: { color: theme.colors.text, width: 240, height: 44 },
@@ -174,7 +197,9 @@ export default function AuthScreen({
           style={styles.themeButton}
           onPress={toggleTheme}
         >
-          <Text style={styles.themeButtonText}>{mode === 'dark' ? '🌙' : '🌞'}</Text>
+          <Text style={styles.themeButtonText}>
+            {mode === 'light' ? '🌞' : mode === 'dark' ? '🌙' : '🎮'}
+          </Text>
         </TouchableOpacity>
       </View>
       <View style={styles.authBox}>

--- a/components/FriendsScreen.tsx
+++ b/components/FriendsScreen.tsx
@@ -79,6 +79,7 @@ export default function FriendsScreen({ visible, onClose, uiLanguage }: { visibl
           fontSize: 22,
           fontWeight: 'bold',
           marginBottom: 8,
+          fontFamily: theme.fontFamily,
         },
         searchRow: { flexDirection: 'row', marginBottom: 8 },
         input: {
@@ -91,6 +92,7 @@ export default function FriendsScreen({ visible, onClose, uiLanguage }: { visibl
           paddingVertical: 8,
           flex: 1,
           marginRight: 6,
+          fontFamily: theme.fontFamily,
         },
         searchButton: {
           backgroundColor: theme.colors.primary,
@@ -111,7 +113,11 @@ export default function FriendsScreen({ visible, onClose, uiLanguage }: { visibl
           paddingVertical: 6,
           marginLeft: 6,
         },
-        buttonText: { color: theme.colors.text, fontWeight: 'bold' },
+        buttonText: {
+          color: theme.colors.text,
+          fontWeight: 'bold',
+          fontFamily: theme.fontFamily,
+        },
         row: {
           flexDirection: 'row',
           justifyContent: 'space-between',
@@ -119,12 +125,18 @@ export default function FriendsScreen({ visible, onClose, uiLanguage }: { visibl
           paddingVertical: 4,
           width: '100%',
         },
-        name: { color: theme.colors.text, fontSize: 15, flex: 1 },
+        name: {
+          color: theme.colors.text,
+          fontSize: 15,
+          flex: 1,
+          fontFamily: theme.fontFamily,
+        },
         levelText: {
           color: theme.colors.accent,
           fontSize: 12,
           flex: 1,
           textAlign: 'right',
+          fontFamily: theme.fontFamily,
         },
         section: {
           alignSelf: 'flex-start',
@@ -132,6 +144,7 @@ export default function FriendsScreen({ visible, onClose, uiLanguage }: { visibl
           marginBottom: 4,
           color: theme.colors.accent,
           fontWeight: 'bold',
+          fontFamily: theme.fontFamily,
         },
         closeButton: {
           marginTop: 12,
@@ -140,8 +153,17 @@ export default function FriendsScreen({ visible, onClose, uiLanguage }: { visibl
           paddingVertical: 10,
           paddingHorizontal: 24,
         },
-        info: { color: theme.colors.success, marginBottom: 6, fontWeight: 'bold' },
-        sentText: { color: theme.colors.accent, fontWeight: 'bold' },
+        info: {
+          color: theme.colors.success,
+          marginBottom: 6,
+          fontWeight: 'bold',
+          fontFamily: theme.fontFamily,
+        },
+        sentText: {
+          color: theme.colors.accent,
+          fontWeight: 'bold',
+          fontFamily: theme.fontFamily,
+        },
       }),
     [theme]
   );

--- a/components/GameStats.tsx
+++ b/components/GameStats.tsx
@@ -30,6 +30,39 @@ export default function GameStats(props: Props) {
   const { score, lives, bestScore, streak, bestStreak, xp, level, theme, t, uiLanguage } = props;
   const values: any = { score, lives, best: bestScore, streak, bestStreak, xp: `${xp}/100`, level };
 
+  const styles = React.useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          flexDirection: 'row',
+          flexWrap: 'wrap',
+          justifyContent: 'center',
+          borderRadius: 16,
+          padding: 8,
+          margin: 8,
+          elevation: 3,
+        },
+        statCard: {
+          alignItems: 'center',
+          margin: 8,
+          minWidth: 60,
+        },
+        statValue: {
+          fontSize: 20,
+          fontWeight: 'bold',
+          marginTop: 2,
+          fontFamily: theme.fontFamily,
+        },
+        statLabel: {
+          fontSize: 12,
+          marginTop: 1,
+          fontWeight: '600',
+          fontFamily: theme.fontFamily,
+        },
+      }),
+    [theme]
+  );
+
   return (
     <View style={[styles.container, { backgroundColor: theme.colors.card }]}>
       {stats.map(stat => (
@@ -46,30 +79,3 @@ export default function GameStats(props: Props) {
     </View>
   );
 }
-
-const styles = StyleSheet.create({
-  container: {
-    flexDirection: 'row',
-    flexWrap: 'wrap',
-    justifyContent: 'center',
-    borderRadius: 16,
-    padding: 8,
-    margin: 8,
-    elevation: 3,
-  },
-  statCard: {
-    alignItems: 'center',
-    margin: 8,
-    minWidth: 60,
-  },
-  statValue: {
-    fontSize: 20,
-    fontWeight: 'bold',
-    marginTop: 2,
-  },
-  statLabel: {
-    fontSize: 12,
-    marginTop: 1,
-    fontWeight: '600',
-  },
-});

--- a/components/LanguageSelector.tsx
+++ b/components/LanguageSelector.tsx
@@ -42,6 +42,7 @@ export const LanguageSelector = ({
           marginBottom: 30,
           fontWeight: 'bold',
           textAlign: 'center',
+          fontFamily: theme.fontFamily,
         },
         buttonGrid: {
           gap: 20,
@@ -71,6 +72,7 @@ export const LanguageSelector = ({
           color: theme.colors.text,
           fontSize: 18,
           fontWeight: 'bold',
+          fontFamily: theme.fontFamily,
         },
         levelLocked: {
           opacity: 0.5,

--- a/components/NotificationBanner.tsx
+++ b/components/NotificationBanner.tsx
@@ -23,6 +23,7 @@ export default function NotificationBanner({ message }: { message: string | null
           color: theme.colors.text,
           fontWeight: 'bold',
           textAlign: 'center',
+          fontFamily: theme.fontFamily,
         },
       }),
     [theme]

--- a/components/ProfileScreen.tsx
+++ b/components/ProfileScreen.tsx
@@ -71,10 +71,21 @@ export default function ProfileScreen({ onClose, visible, uiLanguage, onShowFrie
           color: theme.colors.accent,
           marginBottom: 8,
           letterSpacing: 0.5,
+          fontFamily: theme.fontFamily,
         },
         userBox: { alignItems: 'center', marginBottom: 4 },
-        username: { fontSize: 17, fontWeight: '600', color: theme.colors.text },
-        email: { fontSize: 13, color: '#bbb', marginTop: 1 },
+        username: {
+          fontSize: 17,
+          fontWeight: '600',
+          color: theme.colors.text,
+          fontFamily: theme.fontFamily,
+        },
+        email: {
+          fontSize: 13,
+          color: '#bbb',
+          marginTop: 1,
+          fontFamily: theme.fontFamily,
+        },
         countryBox: {
           flexDirection: 'row',
           alignItems: 'center',
@@ -84,8 +95,12 @@ export default function ProfileScreen({ onClose, visible, uiLanguage, onShowFrie
           paddingVertical: 4,
           marginVertical: 6,
         },
-        flag: { fontSize: 18, marginRight: 6 },
-        country: { fontSize: 14, color: theme.colors.text },
+        flag: { fontSize: 18, marginRight: 6, fontFamily: theme.fontFamily },
+        country: {
+          fontSize: 14,
+          color: theme.colors.text,
+          fontFamily: theme.fontFamily,
+        },
         section: {
           fontSize: 15,
           color: theme.colors.accent,
@@ -93,6 +108,7 @@ export default function ProfileScreen({ onClose, visible, uiLanguage, onShowFrie
           marginTop: 14,
           marginBottom: 4,
           alignSelf: 'flex-start',
+          fontFamily: theme.fontFamily,
         },
         progressBox: { width: '100%', marginTop: 2 },
         langCard: {
@@ -104,8 +120,17 @@ export default function ProfileScreen({ onClose, visible, uiLanguage, onShowFrie
           justifyContent: 'space-between',
           alignItems: 'center',
         },
-        langName: { color: theme.colors.text, fontWeight: 'bold', fontSize: 13 },
-        levels: { color: theme.colors.accent, fontSize: 12 },
+        langName: {
+          color: theme.colors.text,
+          fontWeight: 'bold',
+          fontSize: 13,
+          fontFamily: theme.fontFamily,
+        },
+        levels: {
+          color: theme.colors.accent,
+          fontSize: 12,
+          fontFamily: theme.fontFamily,
+        },
         avatar: { width: 80, height: 80, borderRadius: 40, marginBottom: 8 },
         photoButton: {
           backgroundColor: theme.colors.primary,
@@ -114,7 +139,11 @@ export default function ProfileScreen({ onClose, visible, uiLanguage, onShowFrie
           paddingVertical: 6,
           marginBottom: 8,
         },
-        photoButtonText: { color: theme.colors.text, fontWeight: 'bold' },
+        photoButtonText: {
+          color: theme.colors.text,
+          fontWeight: 'bold',
+          fontFamily: theme.fontFamily,
+        },
         badgesBox: { flexDirection: 'row', flexWrap: 'wrap', marginBottom: 8 },
         badge: {
           backgroundColor: theme.colors.primary,
@@ -125,6 +154,7 @@ export default function ProfileScreen({ onClose, visible, uiLanguage, onShowFrie
           marginRight: 4,
           marginBottom: 4,
           fontSize: 12,
+          fontFamily: theme.fontFamily,
         },
         friendButtonBox: {
           marginTop: 12,
@@ -148,8 +178,15 @@ export default function ProfileScreen({ onClose, visible, uiLanguage, onShowFrie
           paddingHorizontal: 0,
           textAlign: 'center',
           width: '100%',
+          fontFamily: theme.fontFamily,
         },
-        info: { color: '#bbb', fontSize: 15, textAlign: 'center', marginVertical: 8 },
+        info: {
+          color: '#bbb',
+          fontSize: 15,
+          textAlign: 'center',
+          marginVertical: 8,
+          fontFamily: theme.fontFamily,
+        },
       }),
     [theme]
   );

--- a/components/Snippet.tsx
+++ b/components/Snippet.tsx
@@ -178,6 +178,7 @@ const styles = StyleSheet.create({
     alignSelf: 'flex-end',
     marginBottom: 6,
     marginRight: 2,
+    fontFamily: 'Courier New',
   },
   buttonRow: {
     flexDirection: 'row',
@@ -200,6 +201,7 @@ const styles = StyleSheet.create({
     color: 'white',
     fontSize: 18,
     fontWeight: 'bold',
+    fontFamily: 'Courier New',
   },
   goldContainer: {
     borderColor: '#ffd700',
@@ -210,6 +212,7 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     alignSelf: 'center',
     marginBottom: 4,
+    fontFamily: 'Courier New',
   },
   explanationBox: {
     marginTop: 10,
@@ -222,10 +225,12 @@ const styles = StyleSheet.create({
     fontWeight: 'bold',
     marginBottom: 4,
     fontSize: 16,
+    fontFamily: 'Courier New',
   },
   explanationText: {
     color: '#fff',
     fontSize: 15,
+    fontFamily: 'Courier New',
   },
   continueButton: {
     marginTop: 12,
@@ -239,5 +244,6 @@ const styles = StyleSheet.create({
     color: 'white',
     fontWeight: 'bold',
     fontSize: 16,
+    fontFamily: 'Courier New',
   },
 });

--- a/components/ThemeSelector.tsx
+++ b/components/ThemeSelector.tsx
@@ -26,6 +26,7 @@ export default function ThemeSelector({
           marginBottom: 30,
           fontWeight: 'bold',
           textAlign: 'center',
+          fontFamily: theme.fontFamily,
         },
         row: { flexDirection: 'row', gap: 20 },
         button: {
@@ -38,6 +39,7 @@ export default function ThemeSelector({
           color: theme.colors.text,
           fontSize: 18,
           fontWeight: 'bold',
+          fontFamily: theme.fontFamily,
         },
       }),
     [theme]
@@ -51,6 +53,9 @@ export default function ThemeSelector({
         </TouchableOpacity>
         <TouchableOpacity style={styles.button} onPress={() => onSelect('dark')}>
           <Text style={styles.buttonText}>{t(uiLanguage, 'dark')}</Text>
+        </TouchableOpacity>
+        <TouchableOpacity style={styles.button} onPress={() => onSelect('retro')}>
+          <Text style={styles.buttonText}>{t(uiLanguage, 'retro')}</Text>
         </TouchableOpacity>
       </View>
     </View>

--- a/components/UserProfileScreen.tsx
+++ b/components/UserProfileScreen.tsx
@@ -59,10 +59,21 @@ export default function UserProfileScreen({ visible, onClose, username, uiLangua
           color: theme.colors.accent,
           marginBottom: 8,
           letterSpacing: 0.5,
+          fontFamily: theme.fontFamily,
         },
         userBox: { alignItems: 'center', marginBottom: 4 },
-        username: { fontSize: 17, fontWeight: '600', color: theme.colors.text },
-        email: { fontSize: 13, color: '#bbb', marginTop: 1 },
+        username: {
+          fontSize: 17,
+          fontWeight: '600',
+          color: theme.colors.text,
+          fontFamily: theme.fontFamily,
+        },
+        email: {
+          fontSize: 13,
+          color: '#bbb',
+          marginTop: 1,
+          fontFamily: theme.fontFamily,
+        },
         countryBox: {
           flexDirection: 'row',
           alignItems: 'center',
@@ -72,8 +83,12 @@ export default function UserProfileScreen({ visible, onClose, username, uiLangua
           paddingVertical: 2,
           marginVertical: 6,
         },
-        flag: { fontSize: 18, marginRight: 6 },
-        country: { fontSize: 14, color: theme.colors.text },
+        flag: { fontSize: 18, marginRight: 6, fontFamily: theme.fontFamily },
+        country: {
+          fontSize: 14,
+          color: theme.colors.text,
+          fontFamily: theme.fontFamily,
+        },
         section: {
           fontSize: 15,
           color: theme.colors.accent,
@@ -81,6 +96,7 @@ export default function UserProfileScreen({ visible, onClose, username, uiLangua
           marginTop: 14,
           marginBottom: 4,
           alignSelf: 'flex-start',
+          fontFamily: theme.fontFamily,
         },
         progressBox: { width: '100%', marginTop: 2 },
         langCard: {
@@ -92,8 +108,17 @@ export default function UserProfileScreen({ visible, onClose, username, uiLangua
           justifyContent: 'space-between',
           alignItems: 'center',
         },
-        langName: { color: theme.colors.text, fontWeight: 'bold', fontSize: 13 },
-        levels: { color: theme.colors.accent, fontSize: 12 },
+        langName: {
+          color: theme.colors.text,
+          fontWeight: 'bold',
+          fontSize: 13,
+          fontFamily: theme.fontFamily,
+        },
+        levels: {
+          color: theme.colors.accent,
+          fontSize: 12,
+          fontFamily: theme.fontFamily,
+        },
         avatar: { width: 80, height: 80, borderRadius: 40, marginBottom: 8 },
         badgesBox: { flexDirection: 'row', flexWrap: 'wrap', marginBottom: 8 },
         badge: {
@@ -105,6 +130,7 @@ export default function UserProfileScreen({ visible, onClose, username, uiLangua
           marginRight: 4,
           marginBottom: 4,
           fontSize: 12,
+          fontFamily: theme.fontFamily,
         },
         closeButtonBox: {
           marginTop: 14,
@@ -121,6 +147,7 @@ export default function UserProfileScreen({ visible, onClose, username, uiLangua
           paddingHorizontal: 0,
           textAlign: 'center',
           width: '100%',
+          fontFamily: theme.fontFamily,
         },
       }),
     [theme]

--- a/theme.tsx
+++ b/theme.tsx
@@ -1,7 +1,7 @@
 import React, { createContext, useContext, useEffect, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
 
-export type ThemeMode = 'light' | 'dark';
+export type ThemeMode = 'light' | 'dark' | 'retro';
 
 export interface Theme {
   colors: {
@@ -15,6 +15,7 @@ export interface Theme {
     border: string;
     overlay: string;
   };
+  fontFamily: string;
 }
 
 const lightTheme: Theme = {
@@ -29,6 +30,7 @@ const lightTheme: Theme = {
     border: '#e0e0e0',
     overlay: 'rgba(0,0,0,0.5)',
   },
+  fontFamily: 'System',
 };
 
 const darkTheme: Theme = {
@@ -43,6 +45,22 @@ const darkTheme: Theme = {
     border: '#272727',
     overlay: 'rgba(0,0,0,0.7)',
   },
+  fontFamily: 'System',
+};
+
+const retroTheme: Theme = {
+  colors: {
+    background: '#0d1b2a',
+    card: '#1b263b',
+    primary: '#e0e1dd',
+    text: '#e0e1dd',
+    accent: '#ffb703',
+    error: '#ef233c',
+    success: '#06d6a0',
+    border: '#415a77',
+    overlay: 'rgba(0,0,0,0.7)',
+  },
+  fontFamily: 'Courier New',
 };
 
 interface ThemeContextValue {
@@ -64,8 +82,8 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
 
   useEffect(() => {
     AsyncStorage.getItem('themeMode').then(value => {
-      if (value === 'dark' || value === 'light') {
-        setMode(value);
+      if (value === 'dark' || value === 'light' || value === 'retro') {
+        setMode(value as ThemeMode);
       }
     });
   }, []);
@@ -75,7 +93,8 @@ export const ThemeProvider = ({ children }: { children: React.ReactNode }) => {
     AsyncStorage.setItem('themeMode', m);
   };
 
-  const theme = mode === 'dark' ? darkTheme : lightTheme;
+  const theme =
+    mode === 'dark' ? darkTheme : mode === 'retro' ? retroTheme : lightTheme;
 
   return (
     <ThemeContext.Provider value={{ theme, mode, setMode: handleSetMode }}>

--- a/translations.ts
+++ b/translations.ts
@@ -66,6 +66,7 @@ export const translations: Record<Lang, Record<string, string>> = {
     selectTheme: 'Tema Seç',
     light: 'Açık',
     dark: 'Karanlık',
+    retro: 'Retro',
   },
   en: {
     loginTitle: 'Login',
@@ -132,6 +133,7 @@ export const translations: Record<Lang, Record<string, string>> = {
     selectTheme: 'Select Theme',
     light: 'Light',
     dark: 'Dark',
+    retro: 'Retro',
   },
 };
 


### PR DESCRIPTION
## Summary
- add a new `retro` theme with pixel-like colours and font
- support theme cycling (light/dark/retro) in auth screen
- include `retro` option in theme selector and translations
- apply game-style fonts across many screens and stats

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fd26036b883269385aa357ea41428