### PR TITLE
Add game-style header for enhanced UI

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -27,6 +27,7 @@ import NotificationBanner from './components/NotificationBanner';
 import { Lang, t } from './translations';
 import { subscribeFriendRequests } from './systems/friends';
 import GameStats from './components/GameStats';
+import GameHeader from './components/GameHeader';
 
 export default function App() {
   const { theme } = useTheme();
@@ -252,6 +253,7 @@ export default function App() {
     return (
       <View style={{ flex: 1, backgroundColor: theme.colors.background }}>
         {ProfileButton}
+        <GameHeader />
         {/* Sadece dil seçtir, level yok */}
         <LanguageSelector
           onSelect={handleLanguageSelect}
@@ -356,6 +358,7 @@ export default function App() {
         }}
       >
         {ProfileButton}
+        <GameHeader />
         <ActivityIndicator size="large" color={theme.colors.accent} />
         <Text style={{ color: 'white', marginTop: 20 }}>
           {t(uiLanguage, 'loadingQuestions')}
@@ -399,6 +402,7 @@ export default function App() {
         }}
       >
         {ProfileButton}
+        <GameHeader />
         <Text style={{ color: 'red', marginBottom: 20 }}>{fetchError}</Text>
         <Button
           title={t(uiLanguage, 'tryAgain')}
@@ -454,6 +458,7 @@ export default function App() {
     <View
       style={[styles.container, { backgroundColor: theme.colors.background }]}
     >
+      <GameHeader />
       {selectedLanguage && !gameOver && PauseButton}
       {StatsBar}
       <NotificationBanner message={notification} />

--- a/components/GameHeader.tsx
+++ b/components/GameHeader.tsx
@@ -1,0 +1,41 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import Icon from 'react-native-vector-icons/MaterialCommunityIcons';
+import { useTheme } from '../theme';
+
+interface Props {
+  title?: string;
+}
+
+export default function GameHeader({ title = 'CodeQuest' }: Props) {
+  const { theme } = useTheme();
+
+  const styles = React.useMemo(
+    () =>
+      StyleSheet.create({
+        container: {
+          flexDirection: 'row',
+          alignItems: 'center',
+          justifyContent: 'center',
+          marginTop: 24,
+          marginBottom: 12,
+        },
+        title: {
+          fontSize: 28,
+          fontWeight: 'bold',
+          marginLeft: 8,
+          letterSpacing: 2,
+          fontFamily: theme.fontFamily,
+        },
+      }),
+    [theme],
+  );
+
+  return (
+    <View style={styles.container}>
+      <Icon name="gamepad-variant-outline" size={32} color={theme.colors.accent} />
+      <Text style={[styles.title, { color: theme.colors.accent }]}>{title}</Text>
+    </View>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable `GameHeader` component with icon-based title
- display `GameHeader` across language selection, loading, and gameplay screens to give a more game-like look

## Testing
- `npm test` (fails: No tests found)
- `npm run lint` (fails: linter reports existing errors)


------
https://chatgpt.com/codex/tasks/task_e_68a614f5055c83269a06fcf6916a2837