### PR TITLE
Lower top placement for notifications

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -646,7 +646,11 @@ export default function App() {
 
 const createStyles = (theme: any) =>
   StyleSheet.create({
-    container: { flex: 1, backgroundColor: theme.colors.background },
+    container: {
+      flex: 1,
+      backgroundColor: theme.colors.background,
+      paddingTop: 60,
+    },
     gameContainer: { flex: 1 },
     overlay: {
       position: 'absolute',

--- a/components/NotificationBanner.tsx
+++ b/components/NotificationBanner.tsx
@@ -4,13 +4,12 @@ import { useTheme } from '../theme';
 
 export default function NotificationBanner({ message }: { message: string | null }) {
   const { theme } = useTheme();
-  if (!message) return null;
   const styles = React.useMemo(
     () =>
       StyleSheet.create({
         container: {
           position: 'absolute',
-          top: 40,
+          top: 60,
           left: 20,
           right: 20,
           backgroundColor: theme.colors.primary,
@@ -28,6 +27,7 @@ export default function NotificationBanner({ message }: { message: string | null
       }),
     [theme]
   );
+  if (!message) return null;
   return (
     <View style={styles.container} pointerEvents="none">
       <Text style={styles.text}>{message}</Text>


### PR DESCRIPTION
## Summary
- Push main layout content down with extra top padding
- Reposition notification banner lower on screen

## Testing
- `npm test -- --passWithNoTests`
- `npm run lint` *(fails: useMemo unused, missing deps, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a61a5571bc832685de3a737e44432e